### PR TITLE
Fix guide/topic child pages to match W3 Schools layout

### DIFF
--- a/iron-codex-w3-w3schools-next/app/globals.css
+++ b/iron-codex-w3-w3schools-next/app/globals.css
@@ -2,8 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { 
-  --ink:#111827; 
+:root {
+  --ink:#111827;
   --muted:#6b7280;
   --primary: #0a0e27;
   --secondary: #1a1f3a;
@@ -12,6 +12,12 @@
   --danger: #ff4757;
   --warning: #ffa726;
   --success: #2ed573;
+  /* Legacy variable names used in imported HTML guides/topics */
+  --text: var(--ink);
+  --text-muted: var(--muted);
+  --border: #e5e7eb;
+  --glass: rgba(0,0,0,0.03);
+  --glass-border: rgba(0,0,0,0.05);
 }
 
 html,body { 

--- a/iron-codex-w3-w3schools-next/app/guides/[slug]/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/[slug]/page.tsx
@@ -6,11 +6,16 @@ import { notFound } from "next/navigation";
 
 export default function GuidePage({ params }: { params: { slug: string } }) {
   const filePath = path.join(process.cwd(), "content", "guides", `${params.slug}.html`);
+  let mainClass = "";
   let contentHtml: string | null = null;
+  let styleHtml = "";
   try {
     const rawHtml = fs.readFileSync(filePath, "utf-8");
-    const match = rawHtml.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
-    contentHtml = match ? match[1] : null;
+    const mainMatch = rawHtml.match(/<main[^>]*class="([^"]*)"[^>]*>([\s\S]*?)<\/main>/i);
+    const styleMatch = rawHtml.match(/<style[^>]*>([\s\S]*?)<\/style>/i);
+    mainClass = mainMatch ? mainMatch[1] : "";
+    contentHtml = mainMatch ? mainMatch[2] : null;
+    styleHtml = styleMatch ? styleMatch[1] : "";
   } catch {
     contentHtml = null;
   }
@@ -22,11 +27,8 @@ export default function GuidePage({ params }: { params: { slug: string } }) {
   return (
     <>
       <NavBar />
-      <main className="container py-12" id="main">
-        <div className="max-w-4xl mx-auto prose">
-          <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
-        </div>
-      </main>
+      <main id="main" className={mainClass} dangerouslySetInnerHTML={{ __html: contentHtml }} />
+      {styleHtml && <style dangerouslySetInnerHTML={{ __html: styleHtml }} />}
       <Footer />
     </>
   );

--- a/iron-codex-w3-w3schools-next/app/topics/[slug]/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/[slug]/page.tsx
@@ -6,11 +6,16 @@ import { notFound } from "next/navigation";
 
 export default function TopicPage({ params }: { params: { slug: string } }) {
   const filePath = path.join(process.cwd(), "content", "topics", `${params.slug}.html`);
+  let mainClass = "";
   let contentHtml: string | null = null;
+  let styleHtml = "";
   try {
     const rawHtml = fs.readFileSync(filePath, "utf-8");
-    const match = rawHtml.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
-    contentHtml = match ? match[1] : null;
+    const mainMatch = rawHtml.match(/<main[^>]*class="([^"]*)"[^>]*>([\s\S]*?)<\/main>/i);
+    const styleMatch = rawHtml.match(/<style[^>]*>([\s\S]*?)<\/style>/i);
+    mainClass = mainMatch ? mainMatch[1] : "";
+    contentHtml = mainMatch ? mainMatch[2] : null;
+    styleHtml = styleMatch ? styleMatch[1] : "";
   } catch {
     contentHtml = null;
   }
@@ -22,11 +27,8 @@ export default function TopicPage({ params }: { params: { slug: string } }) {
   return (
     <>
       <NavBar />
-      <main className="container py-12" id="main">
-        <div className="max-w-4xl mx-auto prose">
-          <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
-        </div>
-      </main>
+      <main id="main" className={mainClass} dangerouslySetInnerHTML={{ __html: contentHtml }} />
+      {styleHtml && <style dangerouslySetInnerHTML={{ __html: styleHtml }} />}
       <Footer />
     </>
   );


### PR DESCRIPTION
## Summary
- Extract HTML class and style info for guide/topic child pages to render with original layout
- Add legacy CSS variables so imported HTML styles render correctly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c03c9920e483228ceb0d37871e3fd0