### PR TITLE
style: apply w3 layout to guide pages

### DIFF
--- a/iron-codex-w3-w3schools-next/app/guides/[slug]/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/[slug]/page.tsx
@@ -11,6 +11,9 @@ export default function GuidePage({ params }: { params: { slug: string } }) {
     const rawHtml = fs.readFileSync(filePath, "utf-8");
     const match = rawHtml.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
     contentHtml = match ? match[1] : null;
+    if (contentHtml) {
+      contentHtml = contentHtml.replace(/<pre>/g, '<pre class="w3-code">');
+    }
   } catch {
     contentHtml = null;
   }
@@ -22,9 +25,15 @@ export default function GuidePage({ params }: { params: { slug: string } }) {
   return (
     <>
       <NavBar />
-      <main className="container py-12" id="main">
-        <div className="max-w-4xl mx-auto prose">
-          <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
+      <main id="main">
+        <div className="w3-content w3-margin-top">
+          <div className="w3-row">
+            <div className="w3-col l12 s12">
+              <div className="w3-panel">
+                <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
+              </div>
+            </div>
+          </div>
         </div>
       </main>
       <Footer />


### PR DESCRIPTION
## Summary
- wrap guide content in W3Schools-styled containers and grid classes
- convert raw `<pre>` blocks to use `w3-code` for consistent code formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c048df909c83229f36a6ef75998538