### PR TITLE
feat: default to light theme

### DIFF
--- a/iron-codex/assets/css/main.css
+++ b/iron-codex/assets/css/main.css
@@ -2,6 +2,25 @@
 
 /* CSS Variables */
 :root {
+    --primary: #ffffff;
+    --secondary: #e6e9f1;
+    --accent: #00d4ff;
+    --accent-dark: #0099cc;
+    --danger: #ff4757;
+    --warning: #ffa726;
+    --success: #2ed573;
+    --text: #0a0e27;
+    --text-muted: #4a5568;
+    --border: #d0d7e2;
+    --glass: rgba(0, 0, 0, 0.05);
+    --glass-border: rgba(0, 0, 0, 0.1);
+    --shadow: rgba(0, 0, 0, 0.1);
+    --header-bg: rgba(255, 255, 255, 0.95);
+    --nav-menu-bg: rgba(255, 255, 255, 0.98);
+    --gradient: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+}
+
+[data-theme="dark"] {
     --primary: #0a0e27;
     --secondary: #1a1f3a;
     --accent: #00d4ff;
@@ -15,6 +34,8 @@
     --glass: rgba(255, 255, 255, 0.1);
     --glass-border: rgba(255, 255, 255, 0.2);
     --shadow: rgba(0, 0, 0, 0.3);
+    --header-bg: rgba(10, 14, 39, 0.95);
+    --nav-menu-bg: rgba(10, 14, 39, 0.98);
     --gradient: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
 }
 
@@ -66,7 +87,7 @@ a:hover {
 
 /* Header */
 .header {
-    background: rgba(10, 14, 39, 0.95);
+    background: var(--header-bg);
     backdrop-filter: blur(20px);
     border-bottom: 1px solid var(--border);
     position: sticky;
@@ -485,7 +506,7 @@ a:hover {
         left: -100%;
         width: 100%;
         height: calc(100vh - 70px);
-        background: rgba(10, 14, 39, 0.98);
+        background: var(--nav-menu-bg);
         backdrop-filter: blur(20px);
         flex-direction: column;
         align-items: center;

--- a/iron-codex/assets/js/main.js
+++ b/iron-codex/assets/js/main.js
@@ -96,7 +96,7 @@ function initializeInteractiveElements() {
 
 // Theme handling (for future light/dark mode toggle)
 function initializeTheme() {
-    const savedTheme = localStorage.getItem('iron-codex-theme') || 'dark';
+    const savedTheme = localStorage.getItem('iron-codex-theme') || 'light';
     document.documentElement.setAttribute('data-theme', savedTheme);
 }
 


### PR DESCRIPTION
## Summary
- default to light theme when no preference saved
- add `[data-theme="dark"]` CSS overrides and theme-based header/mobile menu backgrounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c037c746588322b0dc4613064b8747