### PR TITLE
feat: load w3 css and Source Sans Pro font

### DIFF
--- a/iron-codex-w3-w3schools-next/app/globals.css
+++ b/iron-codex-w3-w3schools-next/app/globals.css
@@ -1,21 +1,15 @@
-@tailwind base;
-@tailwind components;
 @tailwind utilities;
 
-:root { 
-  --ink:#111827; 
-  --muted:#6b7280;
-  --primary: #0a0e27;
-  --secondary: #1a1f3a;
-  --accent: #00d4ff;
-  --accent-dark: #0099cc;
-  --danger: #ff4757;
-  --warning: #ffa726;
-  --success: #2ed573;
+@font-face {
+  font-family: "Source Sans Pro";
+  src: url("https://fonts.gstatic.com/s/sourcesanspro/v14/6xK3dSBYKcSV-LCoeQqfX1RYOo3qNa7luj6Er24.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
 }
-
-html,body { 
-  @apply bg-white text-[var(--ink)]; 
+body {
+  @apply bg-white text-w3dark;
+  font-family: "Source Sans Pro", "Segoe UI", Arial, sans-serif;
 }
 
 .container { 
@@ -86,8 +80,8 @@ html,body {
 .bg-w3dark-hero { background-color: #282A35; }
 
 /* Navigation improvements */
-.nav-wrap { 
-  @apply container flex items-center gap-3 h-14; 
+.nav-wrap {
+  @apply max-w-[1200px] mx-auto px-5 flex items-center gap-3 h-14;
 }
 .nav-brand { 
   @apply flex items-center gap-2 shrink-0 whitespace-nowrap; 
@@ -100,8 +94,8 @@ html,body {
 }
 
 /* Topics strip */
-.topics-strip { 
-  @apply container h-10 flex items-center gap-4 md:gap-5 overflow-x-auto uppercase text-xs tracking-wide whitespace-nowrap; 
+.topics-strip {
+  @apply max-w-[1200px] mx-auto px-5 h-10 flex items-center gap-4 md:gap-5 overflow-x-auto uppercase text-xs tracking-wide whitespace-nowrap;
 }
 .topics-item { 
   @apply hover:text-w3green whitespace-nowrap; 

--- a/iron-codex-w3-w3schools-next/app/layout.tsx
+++ b/iron-codex-w3-w3schools-next/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import "./globals.css";
+import Head from "next/head";
 
 export const metadata: Metadata = {
   title: "Iron Codex — Cybersecurity Learning Hub",
@@ -10,6 +11,19 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      <Head>
+        <link
+          rel="stylesheet"
+          href="https://www.w3schools.com/w3css/4/w3.css"
+        />
+        <link
+          rel="preload"
+          href="https://fonts.gstatic.com/s/sourcesanspro/v14/6xK3dSBYKcSV-LCoeQqfX1RYOo3qNa7luj6Er24.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+      </Head>
       <body>
         <a href="#main" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 bg-white border px-3 py-2 rounded">Skip to content</a>
         {children}


### PR DESCRIPTION
## Summary
- include W3.CSS and Source Sans Pro font in root layout
- drop Tailwind base styles and configure global font styling
- remove unused color variables and standardize navigation containers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: required interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c04a0f9d70832296d3add712af2b86