### PR TITLE
Refactor guides and topics for w3.css layout

### DIFF
--- a/iron-codex-w3-w3schools-next/content/guides/api-security.html
+++ b/iron-codex-w3-w3schools-next/content/guides/api-security.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>API Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Comprehensive API security guide with 74 practical controls for REST, GraphQL, authentication, and more">
 </head>
 <body data-page="guide">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container guide-content">
+    <main class="w3-container">
         <!-- Guide Header -->
         <section class="guide-header">
             <nav class="breadcrumb">
@@ -44,8 +25,8 @@
         <!-- Table of Contents -->
         <section class="toc-section">
             <h2>Table of Contents</h2>
-            <div class="toc-grid">
-                <div class="toc-column">
+            <div class="w3-row">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#authentication">1. Authentication (12 controls)</a></li>
                         <li><a href="#authorization">2. Authorization (10 controls)</a></li>
@@ -53,7 +34,7 @@
                         <li><a href="#rate-limiting">4. Rate Limiting (8 controls)</a></li>
                     </ul>
                 </div>
-                <div class="toc-column">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#logging-monitoring">5. Logging & Monitoring (12 controls)</a></li>
                         <li><a href="#data-protection">6. Data Protection (9 controls)</a></li>
@@ -69,7 +50,7 @@
             <h2>1. Authentication (12 controls)</h2>
             <p class="section-intro">Establish strong authentication mechanisms for API access with multi-factor authentication, secure token handling, and certificate-based authentication.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Multi-Factor Authentication (MFA)</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -78,7 +59,7 @@
                 <p><strong>Requirement:</strong> Implement OAuth 2.0 with PKCE (Proof Key for Code Exchange) for enhanced security against authorization code interception attacks.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// OAuth 2.0 with PKCE Flow (Node.js)
+                    <div class="w3-example"><pre class="w3-code">// OAuth 2.0 with PKCE Flow (Node.js)
 const crypto = require('crypto');
 const express = require('express');
 const axios = require('axios');
@@ -133,7 +114,7 @@ app.get('/auth/callback', async (req, res) => {
     } catch (error) {
         res.status(400).json({ error: 'Authentication failed' });
     }
-});</code></pre>
+});</pre></div>
                 </div>
                 <div class="validation">
                     <h4>Validation:</h4>
@@ -146,7 +127,7 @@ app.get('/auth/callback', async (req, res) => {
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement JWT Token Validation</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -155,7 +136,7 @@ app.get('/auth/callback', async (req, res) => {
                 <p><strong>Requirement:</strong> Validate JWT tokens with proper signature verification, expiration checks, and audience validation using JWKS rotation.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>const jwt = require('jsonwebtoken');
+                    <div class="w3-example"><pre class="w3-code">const jwt = require('jsonwebtoken');
 const jwksClient = require('jwks-rsa');
 
 const client = jwksClient({
@@ -198,11 +179,11 @@ function validateJWT(req, res, next) {
         req.user = decoded;
         next();
     });
-}</code></pre>
+}</pre></div>
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Certificate-Based mTLS Authentication</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -211,7 +192,7 @@ function validateJWT(req, res, next) {
                 <p><strong>Requirement:</strong> Implement mutual TLS authentication for high-security API endpoints requiring client certificate validation.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Generate certificates for mTLS
+                    <div class="w3-example"><pre class="w3-code"># Generate certificates for mTLS
 # CA certificate
 openssl genrsa -out ca-key.pem 4096
 openssl req -new -x509 -key ca-key.pem -out ca-cert.pem -days 365
@@ -249,7 +230,7 @@ const server = https.createServer(options, (req, res) => {
 
 server.listen(8443, () => {
     console.log('mTLS server listening on port 8443');
-});</code></pre>
+});</pre></div>
                 </div>
             </div>
 
@@ -301,7 +282,7 @@ server.listen(8443, () => {
             <h2>2. Authorization (10 controls)</h2>
             <p class="section-intro">Implement fine-grained authorization controls with role-based access control, attribute-based policies, and scope validation.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Role-Based Access Control (RBAC)</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -310,7 +291,7 @@ server.listen(8443, () => {
                 <p><strong>Requirement:</strong> Implement hierarchical RBAC with role inheritance and principle of least privilege enforcement.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// RBAC Implementation (Node.js)
+                    <div class="w3-example"><pre class="w3-code">// RBAC Implementation (Node.js)
 class RBACManager {
     constructor() {
         this.roles = new Map();
@@ -387,7 +368,7 @@ app.get('/api/admin/users',
     authenticateJWT,
     requirePermission('users', 'read'),
     getUserList
-);</code></pre>
+);</pre></div>
                 </div>
             </div>
 
@@ -439,7 +420,7 @@ app.get('/api/admin/users',
             <h2>3. Input Validation (14 controls)</h2>
             <p class="section-intro">Comprehensive input validation and sanitization to prevent injection attacks, ensure data integrity, and protect against malicious input.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>SQL Injection Prevention</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -448,7 +429,7 @@ app.get('/api/admin/users',
                 <p><strong>Requirement:</strong> Use parameterized queries, stored procedures, and input validation to prevent SQL injection attacks.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// Parameterized Queries (Node.js with mysql2)
+                    <div class="w3-example"><pre class="w3-code">// Parameterized Queries (Node.js with mysql2)
 const mysql = require('mysql2/promise');
 
 class SecureUserRepository {
@@ -492,7 +473,7 @@ class SecureUserRepository {
             user.passwordHash && user.passwordHash.length >= 60
         );
     }
-}</code></pre>
+}</pre></div>
                 </div>
             </div>
 
@@ -560,7 +541,7 @@ class SecureUserRepository {
             <h2>4. Rate Limiting (8 controls)</h2>
             <p class="section-intro">Implement comprehensive rate limiting strategies to protect against abuse, DDoS attacks, and ensure fair resource usage across API consumers.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Token Bucket Rate Limiting</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -569,7 +550,7 @@ class SecureUserRepository {
                 <p><strong>Requirement:</strong> Implement token bucket algorithm with Redis for distributed rate limiting across multiple API gateway instances.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// Token Bucket Rate Limiter with Redis
+                    <div class="w3-example"><pre class="w3-code">// Token Bucket Rate Limiter with Redis
 const redis = require('redis');
 const client = redis.createClient();
 
@@ -627,7 +608,7 @@ class TokenBucketRateLimiter {
             resetTime: now + ((this.capacity - result[1]) / this.refillRate * 1000)
         };
     }
-}</code></pre>
+}</pre></div>
                 </div>
             </div>
 
@@ -671,7 +652,7 @@ class TokenBucketRateLimiter {
             <h2>5. Logging & Monitoring (12 controls)</h2>
             <p class="section-intro">Comprehensive security event logging, performance monitoring, and real-time threat detection for API security visibility and incident response.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Security Event Logging</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -680,7 +661,7 @@ class TokenBucketRateLimiter {
                 <p><strong>Requirement:</strong> Implement comprehensive security event logging with structured logging, correlation IDs, and SIEM integration.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// Security Event Logging System
+                    <div class="w3-example"><pre class="w3-code">// Security Event Logging System
 const winston = require('winston');
 const { ElasticsearchTransport } = require('winston-elasticsearch');
 
@@ -738,7 +719,7 @@ class SecurityLogger {
                request.connection.remoteAddress ||
                request.socket.remoteAddress;
     }
-}</code></pre>
+}</pre></div>
                 </div>
             </div>
 
@@ -798,7 +779,7 @@ class SecurityLogger {
             <h2>6. Data Protection (9 controls)</h2>
             <p class="section-intro">Comprehensive data protection measures including encryption, PII handling, data loss prevention, and secure data lifecycle management.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>End-to-End Encryption</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -807,7 +788,7 @@ class SecurityLogger {
                 <p><strong>Requirement:</strong> Implement AES-256-GCM encryption for data at rest and in transit with proper key management and rotation.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// End-to-End Encryption Service
+                    <div class="w3-example"><pre class="w3-code">// End-to-End Encryption Service
 const crypto = require('crypto');
 const AWS = require('aws-sdk');
 
@@ -845,7 +826,7 @@ class EncryptionService {
             encryptedDataKey: dataKey.encrypted.toString('base64')
         };
     }
-}</code></pre>
+}</pre></div>
                 </div>
             </div>
 
@@ -893,7 +874,7 @@ class EncryptionService {
             <h2>7. API Gateway Security (5 controls)</h2>
             <p class="section-intro">Centralized security enforcement through API gateway configuration including authentication, transformation, load balancing, and monitoring.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Gateway Authentication & Authorization</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -902,7 +883,7 @@ class EncryptionService {
                 <p><strong>Requirement:</strong> Configure API gateway for centralized authentication and authorization with policy enforcement and JWT validation.</p>
                 <div class="implementation">
                     <h4>Implementation Example (Kong Gateway):</h4>
-                    <pre><code># Kong Gateway Configuration
+                    <div class="w3-example"><pre class="w3-code"># Kong Gateway Configuration
 # Add JWT plugin for authentication
 curl -X POST http://localhost:8001/services/api-service/plugins \
   --data "name=jwt" \
@@ -918,7 +899,7 @@ curl -X POST http://localhost:8001/services/api-service/plugins \
 curl -X POST http://localhost:8001/services/api-service/plugins \
   --data "name=rate-limiting" \
   --data "config.minute=100" \
-  --data "config.hour=1000"</code></pre>
+  --data "config.hour=1000"</pre></div>
                 </div>
             </div>
 
@@ -950,7 +931,7 @@ curl -X POST http://localhost:8001/services/api-service/plugins \
             <h2>8. GraphQL Security (4 controls)</h2>
             <p class="section-intro">Specialized security controls for GraphQL APIs including query complexity analysis, depth limiting, and field-level authorization.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Query Complexity Analysis</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -959,7 +940,7 @@ curl -X POST http://localhost:8001/services/api-service/plugins \
                 <p><strong>Requirement:</strong> Implement query complexity analysis to prevent resource exhaustion attacks through expensive nested queries.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// GraphQL Query Complexity Analysis
+                    <div class="w3-example"><pre class="w3-code">// GraphQL Query Complexity Analysis
 const { createComplexityLimitRule } = require('graphql-query-complexity');
 const depthLimit = require('graphql-depth-limit');
 
@@ -989,7 +970,7 @@ const server = new ApolloServer({
         complexityAnalyzer,
         depthLimit(10)
     ]
-});</code></pre>
+});</pre></div>
                 </div>
             </div>
 

--- a/iron-codex-w3-w3schools-next/content/guides/cloud-security.html
+++ b/iron-codex-w3-w3schools-next/content/guides/cloud-security.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cloud Security CDN - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Comprehensive cloud security guide with 59 controls for AWS, Azure, GCP infrastructure security">
 </head>
 <body data-page="guide">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container guide-content">
+    <main class="w3-container">
         <section class="guide-header">
             <nav class="breadcrumb">
                 <a href="../guides.html">Guides</a> / <span>Cloud Security CDN</span>
@@ -42,8 +23,8 @@
 
         <section class="toc-section">
             <h2>Table of Contents</h2>
-            <div class="toc-grid">
-                <div class="toc-column">
+            <div class="w3-row">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#identity-access">1. Identity & Access Management (12 controls)</a></li>
                         <li><a href="#network-security">2. Network Security (10 controls)</a></li>
@@ -51,7 +32,7 @@
                         <li><a href="#compute-security">4. Compute Security (8 controls)</a></li>
                     </ul>
                 </div>
-                <div class="toc-column">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#storage-security">5. Storage Security (7 controls)</a></li>
                         <li><a href="#logging-monitoring">6. Logging & Monitoring (6 controls)</a></li>
@@ -66,7 +47,7 @@
             <h2>1. Identity & Access Management (12 controls)</h2>
             <p class="section-intro">Implement robust IAM controls across cloud providers with least privilege and zero trust principles.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Multi-Factor Authentication</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -75,7 +56,7 @@
                 <p><strong>Requirement:</strong> Enforce MFA for all privileged accounts and administrative access across all cloud platforms.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># AWS CLI - Enable MFA for root account
+                    <div class="w3-example"><pre class="w3-code"># AWS CLI - Enable MFA for root account
 aws iam enable-mfa-device \
   --user-name root \
   --serial-number arn:aws:iam::123456789012:mfa/root-account-mfa-device \
@@ -102,7 +83,7 @@ aws iam enable-mfa-device \
       }
     }
   ]
-}</code></pre>
+}</pre></div>
                 </div>
                 <div class="validation">
                     <h4>Validation:</h4>
@@ -114,7 +95,7 @@ aws iam enable-mfa-device \
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Least Privilege Access</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -123,7 +104,7 @@ aws iam enable-mfa-device \
                 <p><strong>Requirement:</strong> Grant minimum permissions necessary for users and services to perform their functions.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># AWS IAM Policy Example
+                    <div class="w3-example"><pre class="w3-code"># AWS IAM Policy Example
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -141,7 +122,7 @@ aws iam enable-mfa-device \
       }
     }
   ]
-}</code></pre>
+}</pre></div>
                 </div>
                 <div class="best-practices">
                     <h4>Best Practices:</h4>
@@ -154,7 +135,7 @@ aws iam enable-mfa-device \
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Role-Based Access Control</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -163,7 +144,7 @@ aws iam enable-mfa-device \
                 <p><strong>Requirement:</strong> Use predefined roles and groups to manage access instead of individual user permissions.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Create IAM group
+                    <div class="w3-example"><pre class="w3-code"># Create IAM group
 aws iam create-group --group-name Developers
 
 # Attach policy to group
@@ -193,7 +174,7 @@ aws iam add-user-to-group \
       }
     }
   ]
-}</code></pre>
+}</pre></div>
                 </div>
                 <div class="security-notes">
                     <h4>Security Considerations:</h4>
@@ -244,7 +225,7 @@ aws iam add-user-to-group \
             <h2>2. Network Security (10 controls)</h2>
             <p class="section-intro">Secure cloud networks with proper segmentation, access controls, and traffic monitoring.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Network Segmentation</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -253,7 +234,7 @@ aws iam add-user-to-group \
                 <p><strong>Requirement:</strong> Segment network traffic using VPCs, subnets, and security groups to limit blast radius.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Create VPC with public and private subnets
+                    <div class="w3-example"><pre class="w3-code"># Create VPC with public and private subnets
 aws ec2 create-vpc --cidr-block 10.0.0.0/16
 
 # Create public subnet
@@ -279,11 +260,11 @@ aws ec2 authorize-security-group-ingress \
   --group-id sg-12345678 \
   --protocol tcp \
   --port 443 \
-  --cidr 0.0.0.0/0</code></pre>
+  --cidr 0.0.0.0/0</pre></div>
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Configure Network Access Control Lists</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -292,7 +273,7 @@ aws ec2 authorize-security-group-ingress \
                 <p><strong>Requirement:</strong> Implement subnet-level network ACLs as additional layer of defense.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Create Network Security Group
+                    <div class="w3-example"><pre class="w3-code"># Create Network Security Group
 az network nsg create \
   --resource-group myResourceGroup \
   --name myNetworkSecurityGroup
@@ -308,7 +289,7 @@ az network nsg rule create \
   --source-address-prefixes '*' \
   --destination-address-prefixes '*' \
   --access allow \
-  --direction inbound</code></pre>
+  --direction inbound</pre></div>
                 </div>
             </div>
 
@@ -347,7 +328,7 @@ az network nsg rule create \
             <h2>3. Data Protection (9 controls)</h2>
             <p class="section-intro">Protect sensitive data with encryption, classification, and access controls.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Encryption at Rest</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -356,7 +337,7 @@ az network nsg rule create \
                 <p><strong>Requirement:</strong> Encrypt all data stored in cloud services using strong encryption algorithms.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Enable default encryption on S3 bucket
+                    <div class="w3-example"><pre class="w3-code"># Enable default encryption on S3 bucket
 aws s3api put-bucket-encryption \
   --bucket my-secure-bucket \
   --server-side-encryption-configuration '{
@@ -374,7 +355,7 @@ aws s3api put-bucket-encryption \
 aws rds create-db-instance \
   --db-instance-identifier mydbinstance \
   --storage-encrypted \
-  --kms-key-id arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012</code></pre>
+  --kms-key-id arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012</pre></div>
                 </div>
             </div>
 

--- a/iron-codex-w3-w3schools-next/content/guides/containers.html
+++ b/iron-codex-w3-w3schools-next/content/guides/containers.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Containers & Kubernetes - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Comprehensive container security guide with 29 controls for Docker, Kubernetes hardening, and runtime protection">
 </head>
 <body data-page="guide">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container guide-content">
+    <main class="w3-container">
         <section class="guide-header">
             <nav class="breadcrumb">
                 <a href="../guides.html">Guides</a> / <span>Containers & Kubernetes</span>
@@ -42,8 +23,8 @@
 
         <section class="toc-section">
             <h2>Table of Contents</h2>
-            <div class="toc-grid">
-                <div class="toc-column">
+            <div class="w3-row">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#image-security">1. Image Security (8 controls)</a></li>
                         <li><a href="#runtime-security">2. Runtime Security (7 controls)</a></li>
@@ -51,7 +32,7 @@
                         <li><a href="#network-policies">4. Network Policies (4 controls)</a></li>
                     </ul>
                 </div>
-                <div class="toc-column">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#secrets-management">5. Secrets Management (2 controls)</a></li>
                         <li><a href="#monitoring">6. Monitoring & Logging (2 controls)</a></li>
@@ -64,7 +45,7 @@
             <h2>1. Image Security (8 controls)</h2>
             <p class="section-intro">Secure container images through vulnerability scanning, minimal base images, and secure build practices.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Container Image Scanning</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -73,7 +54,7 @@
                 <p><strong>Requirement:</strong> Scan all container images for vulnerabilities before deployment using automated tools.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Trivy scanning in CI/CD pipeline
+                    <div class="w3-example"><pre class="w3-code"># Trivy scanning in CI/CD pipeline
 name: Container Security Scan
 on: [push, pull_request]
 
@@ -118,7 +99,7 @@ services:
     image: postgres:13
     environment:
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: clair</code></pre>
+      POSTGRES_DB: clair</pre></div>
                 </div>
                 <div class="validation">
                     <h4>Validation:</h4>
@@ -131,7 +112,7 @@ services:
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Use Minimal Base Images</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -140,7 +121,7 @@ services:
                 <p><strong>Requirement:</strong> Use distroless or minimal base images to reduce attack surface and vulnerabilities.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Multi-stage Dockerfile with distroless final image
+                    <div class="w3-example"><pre class="w3-code"># Multi-stage Dockerfile with distroless final image
 FROM golang:1.19-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -167,7 +148,7 @@ ENTRYPOINT ["/usr/local/bin/myapp"]
 FROM scratch
 COPY ca-certificates.crt /etc/ssl/certs/
 COPY myapp /myapp
-ENTRYPOINT ["/myapp"]</code></pre>
+ENTRYPOINT ["/myapp"]</pre></div>
                 </div>
                 <div name="best-practices">
                     <h4>Best Practices:</h4>
@@ -180,7 +161,7 @@ ENTRYPOINT ["/myapp"]</code></pre>
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Image Signing and Verification</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -189,7 +170,7 @@ ENTRYPOINT ["/myapp"]</code></pre>
                 <p><strong>Requirement:</strong> Sign container images and verify signatures before deployment to ensure integrity.</p>
                 <div name="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Docker Content Trust (Notary)
+                    <div class="w3-example"><pre class="w3-code"># Docker Content Trust (Notary)
 export DOCKER_CONTENT_TRUST=1
 docker push myregistry.com/myapp:v1.0
 
@@ -220,7 +201,7 @@ spec:
       key: |-
         -----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...
-        -----END PUBLIC KEY-----</code></pre>
+        -----END PUBLIC KEY-----</pre></div>
                 </div>
             </div>
 
@@ -250,7 +231,7 @@ spec:
             <h2>2. Runtime Security (7 controls)</h2>
             <p class="section-intro">Secure container runtime with proper isolation, resource limits, and security contexts.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Security Contexts</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -259,7 +240,7 @@ spec:
                 <p><strong>Requirement:</strong> Configure proper security contexts to run containers with minimal privileges.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Kubernetes Pod Security Context
+                    <div class="w3-example"><pre class="w3-code"># Kubernetes Pod Security Context
 apiVersion: v1
 kind: Pod
 metadata:
@@ -299,11 +280,11 @@ spec:
       mountPath: /tmp
   volumes:
   - name: tmp-volume
-    emptyDir: {}</code></pre>
+    emptyDir: {}</pre></div>
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Enable Runtime Protection</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -312,7 +293,7 @@ spec:
                 <p><strong>Requirement:</strong> Deploy runtime security tools to detect and prevent malicious activity.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Falco runtime security rules
+                    <div class="w3-example"><pre class="w3-code"># Falco runtime security rules
 - rule: Container with Sensitive Mount
   desc: Detect container with sensitive host paths mounted
   condition: >
@@ -350,7 +331,7 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
   deny /sys/fs/cg[^r]*/** wklx,
   deny /sys/firmware/** rwklx,
   deny /sys/kernel/security/** rwklx,
-}</code></pre>
+}</pre></div>
                 </div>
             </div>
 
@@ -380,7 +361,7 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
             <h2>3. Kubernetes Hardening (6 controls)</h2>
             <p class="section-intro">Harden Kubernetes clusters with RBAC, admission controllers, and security policies.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Configure RBAC Properly</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -389,7 +370,7 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
                 <p><strong>Requirement:</strong> Implement least privilege RBAC with proper role separation.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Service Account with minimal permissions
+                    <div class="w3-example"><pre class="w3-code"># Service Account with minimal permissions
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -433,11 +414,11 @@ metadata:
   namespace: production
 spec:
   serviceAccountName: app-service-account
-  automountServiceAccountToken: false  # Disable if not needed</code></pre>
+  automountServiceAccountToken: false  # Disable if not needed</pre></div>
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Pod Security Standards</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -446,7 +427,7 @@ spec:
                 <p><strong>Requirement:</strong> Use Pod Security Standards to enforce security policies at the namespace level.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Namespace with Pod Security Standards
+                    <div class="w3-example"><pre class="w3-code"># Namespace with Pod Security Standards
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -484,7 +465,7 @@ spec:
           container := input.review.object.spec.containers[_]
           not container.securityContext.allowPrivilegeEscalation == false
           msg := "Containers must not allow privilege escalation"
-        }</code></pre>
+        }</pre></div>
                 </div>
             </div>
 

--- a/iron-codex-w3-w3schools-next/content/guides/iam.html
+++ b/iron-codex-w3-w3schools-next/content/guides/iam.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Identity & Access Management - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Comprehensive IAM guide with 47 controls for RBAC, PBAC, SSO, MFA, and identity governance">
 </head>
 <body data-page="guide">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container guide-content">
+    <main class="w3-container">
         <section class="guide-header">
             <nav class="breadcrumb">
                 <a href="../guides.html">Guides</a> / <span>Identity & Access Management</span>
@@ -42,8 +23,8 @@
 
         <section class="toc-section">
             <h2>Table of Contents</h2>
-            <div class="toc-grid">
-                <div class="toc-column">
+            <div class="w3-row">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#authentication">1. Authentication Framework (12 controls)</a></li>
                         <li><a href="#authorization">2. Authorization Models (10 controls)</a></li>
@@ -51,7 +32,7 @@
                         <li><a href="#identity-lifecycle">4. Identity Lifecycle (7 controls)</a></li>
                     </ul>
                 </div>
-                <div class="toc-column">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#governance">5. Identity Governance (5 controls)</a></li>
                         <li><a href="#federation">6. Identity Federation (3 controls)</a></li>
@@ -65,7 +46,7 @@
             <h2>1. Authentication Framework (12 controls)</h2>
             <p class="section-intro">Establish robust authentication mechanisms with multi-factor authentication and adaptive security.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Multi-Factor Authentication (MFA)</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -74,7 +55,7 @@
                 <p><strong>Requirement:</strong> Enforce MFA for all user accounts with support for multiple authentication factors.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Azure AD Conditional Access Policy
+                    <div class="w3-example"><pre class="w3-code"># Azure AD Conditional Access Policy
 {
   "displayName": "Require MFA for All Users",
   "state": "enabled",
@@ -115,7 +96,7 @@ function verifyMFAToken(userSecret, token) {
         token: token,
         window: 2
     });
-}</code></pre>
+}</pre></div>
                 </div>
                 <div class="validation">
                     <h4>Validation:</h4>
@@ -128,7 +109,7 @@ function verifyMFAToken(userSecret, token) {
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Single Sign-On (SSO)</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -137,7 +118,7 @@ function verifyMFAToken(userSecret, token) {
                 <p><strong>Requirement:</strong> Deploy enterprise SSO solution with SAML 2.0 or OpenID Connect support.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># SAML 2.0 Configuration (XML)
+                    <div class="w3-example"><pre class="w3-code"># SAML 2.0 Configuration (XML)
 <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
                   entityID="https://myapp.com/saml/metadata">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
@@ -170,7 +151,7 @@ async function setupOIDC() {
     return new Strategy({ client }, (tokenSet, userinfo, done) => {
         return done(null, userinfo);
     });
-}</code></pre>
+}</pre></div>
                 </div>
                 <div class="best-practices">
                     <h4>Best Practices:</h4>
@@ -183,7 +164,7 @@ async function setupOIDC() {
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Adaptive Authentication</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -192,7 +173,7 @@ async function setupOIDC() {
                 <p><strong>Requirement:</strong> Deploy risk-based authentication that adapts security requirements based on context.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Risk Assessment Engine (Python)
+                    <div class="w3-example"><pre class="w3-code"># Risk Assessment Engine (Python)
 import geoip2.database
 from datetime import datetime, timedelta
 
@@ -238,7 +219,7 @@ class AdaptiveAuthEngine:
         elif risk_score >= 30:
             return ['password', 'mfa']
         else:
-            return ['password']</code></pre>
+            return ['password']</pre></div>
                 </div>
                 <div class="security-notes">
                     <h4>Security Considerations:</h4>
@@ -289,7 +270,7 @@ class AdaptiveAuthEngine:
             <h2>2. Authorization Models (10 controls)</h2>
             <p class="section-intro">Implement comprehensive authorization with RBAC, ABAC, and fine-grained access controls.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Role-Based Access Control (RBAC)</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -298,7 +279,7 @@ class AdaptiveAuthEngine:
                 <p><strong>Requirement:</strong> Deploy hierarchical RBAC system with inheritance and role separation.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># RBAC Database Schema
+                    <div class="w3-example"><pre class="w3-code"># RBAC Database Schema
 CREATE TABLE roles (
     id UUID PRIMARY KEY,
     name VARCHAR(100) UNIQUE NOT NULL,
@@ -358,11 +339,11 @@ class RBACEngine:
         """
         
         result = self.db.execute(query, (user_id, resource, action))
-        return result.fetchone()['has_permission']</code></pre>
+        return result.fetchone()['has_permission']</pre></div>
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Attribute-Based Access Control (ABAC)</h3>
                 <div class="control-tags">
                     <span class="tag priority-medium">Medium Priority</span>
@@ -371,7 +352,7 @@ class RBACEngine:
                 <p><strong>Requirement:</strong> Deploy ABAC for complex authorization scenarios with dynamic policies.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># XACML Policy Example
+                    <div class="w3-example"><pre class="w3-code"># XACML Policy Example
 <Policy PolicyId="DocumentAccess" RuleCombiningAlgId="first-applicable">
   <Rule RuleId="OwnerAccess" Effect="Permit">
     <Condition>
@@ -404,7 +385,7 @@ class RBACEngine:
       </Apply>
     </Condition>
   </Rule>
-</Policy></code></pre>
+</Policy></pre></div>
                 </div>
             </div>
 

--- a/iron-codex-w3-w3schools-next/content/guides/incident-response.html
+++ b/iron-codex-w3-w3schools-next/content/guides/incident-response.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Logging & Incident Response - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Comprehensive incident response guide with 25 controls for SIEM, logging, threat detection, and response procedures">
 </head>
 <body data-page="guide">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container guide-content">
+    <main class="w3-container">
         <section class="guide-header">
             <nav class="breadcrumb">
                 <a href="../guides.html">Guides</a> / <span>Logging & Incident Response</span>
@@ -42,15 +23,15 @@
 
         <section class="toc-section">
             <h2>Table of Contents</h2>
-            <div class="toc-grid">
-                <div class="toc-column">
+            <div class="w3-row">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#logging-framework">1. Logging Framework (7 controls)</a></li>
                         <li><a href="#siem-deployment">2. SIEM Deployment (6 controls)</a></li>
                         <li><a href="#threat-detection">3. Threat Detection (5 controls)</a></li>
                     </ul>
                 </div>
-                <div class="toc-column">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#incident-response">4. Incident Response (4 controls)</a></li>
                         <li><a href="#forensics">5. Digital Forensics (2 controls)</a></li>
@@ -64,7 +45,7 @@
             <h2>1. Logging Framework (7 controls)</h2>
             <p class="section-intro">Establish comprehensive logging infrastructure with proper collection, storage, and retention policies.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Centralized Log Management</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -73,7 +54,7 @@
                 <p><strong>Requirement:</strong> Deploy centralized logging system to collect, aggregate, and store logs from all systems.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># ELK Stack Docker Compose Configuration
+                    <div class="w3-example"><pre class="w3-code"># ELK Stack Docker Compose Configuration
 version: '3.8'
 services:
   elasticsearch:
@@ -175,7 +156,7 @@ output {
     password => "changeme"
     index => "logs-%{+YYYY.MM.dd}"
   }
-}</code></pre>
+}</pre></div>
                 </div>
                 <div class="validation">
                     <h4>Validation:</h4>
@@ -188,7 +169,7 @@ output {
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Configure Security Event Logging</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -197,7 +178,7 @@ output {
                 <p><strong>Requirement:</strong> Log all security-relevant events with appropriate detail and context.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Application Security Logging (Python)
+                    <div class="w3-example"><pre class="w3-code"># Application Security Logging (Python)
 import logging
 import json
 from datetime import datetime
@@ -273,7 +254,7 @@ def login():
         security_logger.log_authentication_event(
             username, 'login', False, {'method': 'password', 'reason': 'invalid_credentials'}
         )
-        return jsonify({'error': 'Invalid credentials'}), 401</code></pre>
+        return jsonify({'error': 'Invalid credentials'}), 401</pre></div>
                 </div>
                 <div class="best-practices">
                     <h4>Best Practices:</h4>
@@ -286,7 +267,7 @@ def login():
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Log Integrity Protection</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -295,7 +276,7 @@ def login():
                 <p><strong>Requirement:</strong> Protect log integrity using cryptographic methods and tamper detection.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Log Integrity Protection (Python)
+                    <div class="w3-example"><pre class="w3-code"># Log Integrity Protection (Python)
 import hashlib
 import hmac
 import json
@@ -380,7 +361,7 @@ entry2 = logger.create_log_entry("Failed authentication", "WARN")
 
 # Verify log integrity
 entries = [entry1, entry2]
-is_valid, message = logger.verify_log_chain(entries)</code></pre>
+is_valid, message = logger.verify_log_chain(entries)</pre></div>
                 </div>
                 <div class="security-notes">
                     <h4>Security Considerations:</h4>
@@ -416,7 +397,7 @@ is_valid, message = logger.verify_log_chain(entries)</code></pre>
             <h2>2. SIEM Deployment (6 controls)</h2>
             <p class="section-intro">Deploy and configure SIEM solutions for comprehensive security monitoring and analysis.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Configure SIEM Rules and Correlation</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -425,7 +406,7 @@ is_valid, message = logger.verify_log_chain(entries)</code></pre>
                 <p><strong>Requirement:</strong> Implement correlation rules to detect security events and attack patterns.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code># Elasticsearch Watcher Rules for Security Events
+                    <div class="w3-example"><pre class="w3-code"># Elasticsearch Watcher Rules for Security Events
 # Brute Force Detection
 PUT _watcher/watch/brute_force_detection
 {
@@ -573,7 +554,7 @@ PUT _watcher/watch/suspicious_login_pattern
       }
     }
   }
-}</code></pre>
+}</pre></div>
                 </div>
             </div>
 

--- a/iron-codex-w3-w3schools-next/content/guides/saas-security.html
+++ b/iron-codex-w3-w3schools-next/content/guides/saas-security.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SaaS Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Comprehensive SaaS security guide with 59 controls for multi-tenant platforms, data isolation, and enterprise security">
 </head>
 <body data-page="guide">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container guide-content">
+    <main class="w3-container">
         <section class="guide-header">
             <nav class="breadcrumb">
                 <a href="../guides.html">Guides</a> / <span>SaaS Security</span>
@@ -42,8 +23,8 @@
 
         <section class="toc-section">
             <h2>Table of Contents</h2>
-            <div class="toc-grid">
-                <div class="toc-column">
+            <div class="w3-row">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#tenant-isolation">1. Multi-Tenant Isolation (12 controls)</a></li>
                         <li><a href="#data-security">2. Data Security & Privacy (11 controls)</a></li>
@@ -51,7 +32,7 @@
                         <li><a href="#api-security">4. API & Integration Security (8 controls)</a></li>
                     </ul>
                 </div>
-                <div class="toc-column">
+                <div class="w3-col">
                     <ul class="toc-list">
                         <li><a href="#compliance">5. Compliance & Governance (7 controls)</a></li>
                         <li><a href="#monitoring">6. Monitoring & Logging (6 controls)</a></li>
@@ -66,7 +47,7 @@
             <h2>1. Multi-Tenant Isolation (12 controls)</h2>
             <p class="section-intro">Ensure complete isolation between tenants to prevent data leakage and unauthorized access across customer boundaries.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Database-Level Tenant Isolation</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -75,7 +56,7 @@
                 <p><strong>Requirement:</strong> Implement robust database isolation using either separate schemas, databases, or row-level security policies.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>-- Enable RLS on table
+                    <div class="w3-example"><pre class="w3-code">-- Enable RLS on table
 ALTER TABLE customer_data ENABLE ROW LEVEL SECURITY;
 
 -- Create policy for tenant isolation
@@ -96,7 +77,7 @@ const setTenantContext = (req, res, next) => {
     });
 };
 
-app.use(setTenantContext);</code></pre>
+app.use(setTenantContext);</pre></div>
                 </div>
                 <div class="validation">
                     <h4>Validation:</h4>
@@ -108,7 +89,7 @@ app.use(setTenantContext);</code></pre>
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Application-Level Tenant Filtering</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -117,7 +98,7 @@ app.use(setTenantContext);</code></pre>
                 <p><strong>Requirement:</strong> Implement consistent tenant filtering in all application queries and operations.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// Base model with tenant scoping
+                    <div class="w3-example"><pre class="w3-code">// Base model with tenant scoping
 class BaseModel extends Sequelize.Model {
     static init(attributes, options) {
         return super.init(attributes, {
@@ -141,7 +122,7 @@ Customer.init({
 }, { sequelize });
 
 // Usage - automatically filters by current tenant
-const customers = await Customer.findAll(); // Only returns current tenant's customers</code></pre>
+const customers = await Customer.findAll(); // Only returns current tenant's customers</pre></div>
                 </div>
                 <div class="best-practices">
                     <h4>Best Practices:</h4>
@@ -154,7 +135,7 @@ const customers = await Customer.findAll(); // Only returns current tenant's cus
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Network-Level Tenant Isolation</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -163,7 +144,7 @@ const customers = await Customer.findAll(); // Only returns current tenant's cus
                 <p><strong>Requirement:</strong> Implement network segmentation to isolate tenant traffic and prevent cross-tenant network access.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>apiVersion: networking.k8s.io/v1
+                    <div class="w3-example"><pre class="w3-code">apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: tenant-isolation-policy
@@ -188,7 +169,7 @@ spec:
           name: tenant-123
     - namespaceSelector:
         matchLabels:
-          name: shared-services</code></pre>
+          name: shared-services</pre></div>
                 </div>
                 <div class="security-notes">
                     <h4>Security Considerations:</h4>
@@ -239,7 +220,7 @@ spec:
             <h2>2. Data Security & Privacy (11 controls)</h2>
             <p class="section-intro">Protect sensitive customer data with encryption, classification, and privacy controls.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Data Classification and Labeling</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -248,7 +229,7 @@ spec:
                 <p><strong>Requirement:</strong> Classify and label data based on sensitivity levels and regulatory requirements.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// Data classification enum
+                    <div class="w3-example"><pre class="w3-code">// Data classification enum
 enum DataClassification {
     PUBLIC = 'public',
     INTERNAL = 'internal',
@@ -285,11 +266,11 @@ class CustomerData extends BaseModel {
         if (data.ssn && /^\d{3}-\d{2}-\d{4}$/.test(data.ssn)) piiFields.push('ssn');
         return piiFields;
     }
-}</code></pre>
+}</pre></div>
                 </div>
             </div>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Field-Level Encryption</h3>
                 <div class="control-tags">
                     <span class="tag priority-critical">Critical</span>
@@ -298,7 +279,7 @@ class CustomerData extends BaseModel {
                 <p><strong>Requirement:</strong> Encrypt sensitive data fields using strong encryption with proper key management.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>const crypto = require('crypto');
+                    <div class="w3-example"><pre class="w3-code">const crypto = require('crypto');
 const AWS = require('aws-sdk');
 const kms = new AWS.KMS();
 
@@ -329,7 +310,7 @@ class FieldEncryption {
         const result = await kms.decrypt(params).promise();
         return result.Plaintext.toString();
     }
-}</code></pre>
+}</pre></div>
                 </div>
             </div>
 
@@ -371,7 +352,7 @@ class FieldEncryption {
             <h2>3. Access Control & IAM (10 controls)</h2>
             <p class="section-intro">Implement comprehensive access controls with role-based permissions and multi-factor authentication.</p>
 
-            <div class="control-card">
+            <div class="w3-panel">
                 <h3>Implement Role-Based Access Control (RBAC)</h3>
                 <div class="control-tags">
                     <span class="tag priority-high">High Priority</span>
@@ -380,7 +361,7 @@ class FieldEncryption {
                 <p><strong>Requirement:</strong> Define granular roles and permissions for different user types across tenants.</p>
                 <div class="implementation">
                     <h4>Implementation Example:</h4>
-                    <pre><code>// Permission-based authorization
+                    <div class="w3-example"><pre class="w3-code">// Permission-based authorization
 const permissions = {
     'users:read': 'Read user information',
     'users:write': 'Create and update users',
@@ -414,7 +395,7 @@ const requirePermission = (permission) => {
 
 // Usage
 app.get('/api/users', requirePermission('users:read'), getUsersHandler);
-app.post('/api/users', requirePermission('users:write'), createUserHandler);</code></pre>
+app.post('/api/users', requirePermission('users:write'), createUserHandler);</pre></div>
                 </div>
             </div>
 

--- a/iron-codex-w3-w3schools-next/content/topics/api-security.html
+++ b/iron-codex-w3-w3schools-next/content/topics/api-security.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>API Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="REST/GraphQL security, authentication, rate limiting, input validation, and API gateway protection">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>API Security</span>
@@ -46,20 +27,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>Authentication & Authorization</h4>
                         <p>OAuth 2.0, JWT tokens, API keys, and access control mechanisms</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Input Validation</h4>
                         <p>Comprehensive validation of API requests and data sanitization</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Rate Limiting</h4>
                         <p>Throttling mechanisms to prevent abuse and DDoS attacks</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>API Gateway Security</h4>
                         <p>Centralized security policy enforcement and management</p>
                     </div>
@@ -73,7 +54,7 @@
             <div class="control-group">
                 <h3>Authentication & Authorization</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement OAuth 2.0 / OpenID Connect</h4>
                     <p>Use industry-standard OAuth 2.0 for API authentication with OpenID Connect for identity.</p>
                     <div class="implementation-example">
@@ -87,17 +68,17 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>JWT Token Security</h4>
                     <p>Properly implement and validate JSON Web Tokens with strong signing algorithms.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>API Key Management</h4>
                     <p>Secure generation, distribution, and rotation of API keys.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Fine-Grained Authorization</h4>
                     <p>Implement resource-level and operation-level access controls.</p>
                 </div>
@@ -106,27 +87,27 @@
             <div class="control-group">
                 <h3>Input Validation & Data Protection</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Comprehensive Input Validation</h4>
                     <p>Validate all API inputs including headers, parameters, and request bodies.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Schema Validation</h4>
                     <p>Use JSON Schema or OpenAPI specifications to validate request/response structure.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>SQL Injection Prevention</h4>
                     <p>Use parameterized queries and ORM frameworks to prevent injection attacks.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>NoSQL Injection Prevention</h4>
                     <p>Implement proper input sanitization for NoSQL databases.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Encryption</h4>
                     <p>Encrypt sensitive data in transit and at rest using strong encryption.</p>
                 </div>
@@ -135,17 +116,17 @@
             <div class="control-group">
                 <h3>Rate Limiting & DDoS Protection</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Request Rate Limiting</h4>
                     <p>Implement per-user and per-IP rate limiting to prevent abuse.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Burst Protection</h4>
                     <p>Handle traffic spikes while maintaining legitimate user access.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Resource-Based Rate Limits</h4>
                     <p>Different rate limits for different API endpoints based on resource intensity.</p>
                 </div>
@@ -154,17 +135,17 @@
             <div class="control-group">
                 <h3>API Gateway & Infrastructure</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>API Gateway Security</h4>
                     <p>Centralize security policies through API gateway implementation.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Load Balancing & Failover</h4>
                     <p>Implement proper load distribution and failover mechanisms.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>API Versioning Security</h4>
                     <p>Secure handling of API versions and deprecated endpoints.</p>
                 </div>
@@ -173,17 +154,17 @@
             <div class="control-group">
                 <h3>Monitoring & Logging</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Comprehensive API Logging</h4>
                     <p>Log all API requests, responses, and security events for monitoring.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Real-time Monitoring</h4>
                     <p>Monitor API performance, errors, and security threats in real-time.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Anomaly Detection</h4>
                     <p>Implement behavioral analysis to detect unusual API usage patterns.</p>
                 </div>
@@ -192,27 +173,27 @@
             <div class="control-group">
                 <h3>Testing & Validation</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Automated Security Testing</h4>
                     <p>Integrate API security testing into CI/CD pipelines.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Penetration Testing</h4>
                     <p>Regular manual testing of API security controls.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Vulnerability Scanning</h4>
                     <p>Automated scanning for known API vulnerabilities and misconfigurations.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>API Documentation Security</h4>
                     <p>Ensure API documentation doesn't expose sensitive information.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Dependency Management</h4>
                     <p>Regular updates and vulnerability scanning of API dependencies.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/business-continuity.html
+++ b/iron-codex-w3-w3schools-next/content/topics/business-continuity.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Business Continuity - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Disaster recovery, backup strategies, RTO/RPO planning, resilience engineering, and crisis management">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Business Continuity</span>
@@ -46,20 +27,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>Disaster Recovery</h4>
                         <p>Technical recovery of IT systems and infrastructure after disruptive events</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Business Impact Analysis</h4>
                         <p>Assessment of critical business functions and recovery time objectives</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Crisis Management</h4>
                         <p>Coordinated response to manage communications and stakeholder relationships</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Resilience Planning</h4>
                         <p>Building organizational resilience and adaptive capacity for future disruptions</p>
                     </div>
@@ -73,7 +54,7 @@
             <div class="control-group">
                 <h3>Planning & Assessment</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Business Impact Analysis (BIA)</h4>
                     <p>Identify critical business functions and assess potential impact of disruptions.</p>
                     <div class="implementation-example">
@@ -87,12 +68,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Risk Assessment and Analysis</h4>
                     <p>Assess threats and vulnerabilities that could disrupt business operations.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Business Continuity Strategy</h4>
                     <p>Develop comprehensive strategy for maintaining business operations.</p>
                 </div>
@@ -101,7 +82,7 @@
             <div class="control-group">
                 <h3>Disaster Recovery</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Disaster Recovery Planning</h4>
                     <p>Create detailed plans for IT system and infrastructure recovery.</p>
                     <div class="implementation-example">
@@ -115,12 +96,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Backup and Recovery Systems</h4>
                     <p>Implement robust backup and recovery capabilities for critical data and systems.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Alternative Site Management</h4>
                     <p>Establish and maintain alternative sites for business operations.</p>
                 </div>
@@ -129,17 +110,17 @@
             <div class="control-group">
                 <h3>Crisis Management</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Crisis Management Team</h4>
                     <p>Establish trained crisis management team with clear roles and responsibilities.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Emergency Communication</h4>
                     <p>Implement communication systems for emergency response and stakeholder updates.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Stakeholder Management</h4>
                     <p>Manage communications with customers, suppliers, employees, and other stakeholders.</p>
                 </div>
@@ -148,17 +129,17 @@
             <div class="control-group">
                 <h3>Testing & Maintenance</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Plan Testing and Exercises</h4>
                     <p>Regularly test business continuity and disaster recovery plans.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Plan Maintenance and Updates</h4>
                     <p>Keep business continuity plans current and aligned with business changes.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Training and Awareness</h4>
                     <p>Train employees on business continuity procedures and their roles.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/cloud-security.html
+++ b/iron-codex-w3-w3schools-next/content/topics/cloud-security.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cloud Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="AWS, Azure, GCP security, container orchestration, serverless security, and multi-cloud strategies">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Cloud Security</span>
@@ -45,19 +26,19 @@
             
             <div class="control-group">
                 <h3>Identity & Access Management</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Cloud IAM Implementation</h4>
                     <p>Implement proper identity and access management across all cloud platforms.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Multi-Factor Authentication</h4>
                     <p>Enforce MFA for all administrative and privileged cloud access.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Service Account Security</h4>
                     <p>Secure service accounts with proper permissions and key rotation.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Cross-Account Access Control</h4>
                     <p>Secure cross-account access with proper trust relationships.</p>
                 </div>
@@ -65,19 +46,19 @@
 
             <div class="control-group">
                 <h3>Network Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Virtual Private Cloud (VPC) Security</h4>
                     <p>Implement proper VPC configuration with subnets and security groups.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Network Segmentation</h4>
                     <p>Segment cloud networks to limit attack spread and improve monitoring.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>VPN and Private Connectivity</h4>
                     <p>Secure connectivity between on-premises and cloud environments.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Web Application Firewall</h4>
                     <p>Deploy cloud WAF to protect web applications from attacks.</p>
                 </div>
@@ -85,19 +66,19 @@
 
             <div class="control-group">
                 <h3>Data Protection</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Encryption at Rest</h4>
                     <p>Encrypt all data stored in cloud services using strong encryption algorithms.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Encryption in Transit</h4>
                     <p>Ensure all data transmission uses TLS/SSL encryption.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Key Management</h4>
                     <p>Implement proper cryptographic key management and rotation.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Classification</h4>
                     <p>Classify and label data based on sensitivity and regulatory requirements.</p>
                 </div>
@@ -105,15 +86,15 @@
 
             <div class="control-group">
                 <h3>Compute Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Instance Security Hardening</h4>
                     <p>Harden cloud compute instances with proper configuration and patching.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Container Security</h4>
                     <p>Secure containerized applications and orchestration platforms.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Serverless Security</h4>
                     <p>Implement security controls for serverless functions and applications.</p>
                 </div>
@@ -121,15 +102,15 @@
 
             <div class="control-group">
                 <h3>Storage Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Object Storage Security</h4>
                     <p>Secure cloud object storage with proper access controls and encryption.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Database Security</h4>
                     <p>Implement security controls for cloud database services.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Backup Security</h4>
                     <p>Secure backup data with encryption and access controls.</p>
                 </div>
@@ -137,15 +118,15 @@
 
             <div class="control-group">
                 <h3>Monitoring & Logging</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Cloud Trail Logging</h4>
                     <p>Enable comprehensive logging of all cloud API calls and activities.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Monitoring</h4>
                     <p>Implement real-time monitoring for security events and anomalies.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Log Analysis and SIEM</h4>
                     <p>Aggregate and analyze cloud logs for security insights.</p>
                 </div>
@@ -153,15 +134,15 @@
 
             <div class="control-group">
                 <h3>Compliance & Governance</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Cloud Compliance Framework</h4>
                     <p>Implement compliance controls for relevant regulations and standards.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Configuration Management</h4>
                     <p>Ensure cloud resources are configured according to security policies.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Assessment</h4>
                     <p>Regular security assessments and penetration testing of cloud infrastructure.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/compliance-audit.html
+++ b/iron-codex-w3-w3schools-next/content/topics/compliance-audit.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Compliance & Audit - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="SOX, PCI-DSS, HIPAA, ISO 27001, audit procedures, and regulatory framework implementation">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Compliance & Audit</span>
@@ -46,20 +27,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>Regulatory Frameworks</h4>
                         <p>Understanding and implementing various regulatory requirements and industry standards</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Control Implementation</h4>
                         <p>Designing and implementing security controls to meet compliance requirements</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Audit Management</h4>
                         <p>Preparing for and managing internal and external audits and assessments</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Continuous Monitoring</h4>
                         <p>Ongoing monitoring and measurement of compliance status and control effectiveness</p>
                     </div>
@@ -73,7 +54,7 @@
             <div class="control-group">
                 <h3>Compliance Framework</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Regulatory Requirements Assessment</h4>
                     <p>Identify and document all applicable regulatory and compliance requirements.</p>
                     <div class="implementation-example">
@@ -87,12 +68,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Compliance Program Management</h4>
                     <p>Establish governance structure for ongoing compliance management.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Policy and Procedure Development</h4>
                     <p>Create policies and procedures that address regulatory requirements.</p>
                 </div>
@@ -101,7 +82,7 @@
             <div class="control-group">
                 <h3>Control Implementation</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Control Design and Implementation</h4>
                     <p>Design and implement security controls to meet compliance requirements.</p>
                     <div class="implementation-example">
@@ -115,12 +96,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Control Testing and Validation</h4>
                     <p>Regularly test and validate the effectiveness of implemented controls.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Remediation Management</h4>
                     <p>Track and manage remediation of control deficiencies and gaps.</p>
                 </div>
@@ -129,22 +110,22 @@
             <div class="control-group">
                 <h3>Audit Management</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Internal Audit Program</h4>
                     <p>Establish regular internal audit processes and procedures.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>External Audit Coordination</h4>
                     <p>Manage relationships and coordination with external auditors.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Evidence Management</h4>
                     <p>Collect, organize, and maintain audit evidence and documentation.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Audit Response Management</h4>
                     <p>Manage responses to audit findings and recommendations.</p>
                 </div>
@@ -153,27 +134,27 @@
             <div class="control-group">
                 <h3>Monitoring & Reporting</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Compliance Monitoring</h4>
                     <p>Implement continuous monitoring of compliance status.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Compliance Reporting</h4>
                     <p>Generate regular compliance reports for stakeholders.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Metrics and KPIs</h4>
                     <p>Define and track key compliance metrics and performance indicators.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Risk Assessment Integration</h4>
                     <p>Integrate compliance requirements into risk assessment processes.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Training and Awareness</h4>
                     <p>Provide compliance training and awareness for relevant personnel.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/container-security.html
+++ b/iron-codex-w3-w3schools-next/content/topics/container-security.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Container Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Docker security, Kubernetes hardening, image scanning, runtime protection, and orchestration security">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Container Security</span>
@@ -45,19 +26,19 @@
             
             <div class="control-group">
                 <h3>Image Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Image Vulnerability Scanning</h4>
                     <p>Scan container images for vulnerabilities before deployment.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Base Image Security</h4>
                     <p>Use minimal, distroless, or hardened base images.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Image Signing</h4>
                     <p>Sign and verify container image integrity.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Registry Security</h4>
                     <p>Secure container registries with access controls.</p>
                 </div>
@@ -65,19 +46,19 @@
 
             <div class="control-group">
                 <h3>Runtime Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Container Runtime Hardening</h4>
                     <p>Configure secure container runtime settings.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Contexts</h4>
                     <p>Implement proper security contexts and capabilities.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Resource Limits</h4>
                     <p>Set CPU, memory, and I/O resource constraints.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Runtime Monitoring</h4>
                     <p>Monitor container behavior for anomalies.</p>
                 </div>
@@ -85,19 +66,19 @@
 
             <div class="control-group">
                 <h3>Kubernetes Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>RBAC Implementation</h4>
                     <p>Implement role-based access control in Kubernetes.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Pod Security Standards</h4>
                     <p>Enforce pod security policies and standards.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Network Policies</h4>
                     <p>Control network traffic between pods and services.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>API Server Security</h4>
                     <p>Secure Kubernetes API server configuration.</p>
                 </div>
@@ -105,15 +86,15 @@
 
             <div class="control-group">
                 <h3>Secrets & Configuration</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secrets Management</h4>
                     <p>Secure handling of sensitive configuration data.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Configuration Security</h4>
                     <p>Secure container and orchestrator configuration.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Environment Isolation</h4>
                     <p>Proper isolation between development, staging, and production.</p>
                 </div>
@@ -121,19 +102,19 @@
 
             <div class="control-group">
                 <h3>Monitoring & Compliance</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Audit Logging</h4>
                     <p>Comprehensive logging of container and orchestrator events.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Compliance Scanning</h4>
                     <p>Regular compliance checks against security benchmarks.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Incident Response</h4>
                     <p>Container-specific incident response procedures.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Backup and Recovery</h4>
                     <p>Secure backup strategies for containerized applications.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/cryptography.html
+++ b/iron-codex-w3-w3schools-next/content/topics/cryptography.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cryptography - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Encryption algorithms, hashing, digital signatures, PKI, key management, and crypto implementations">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Cryptography</span>
@@ -45,15 +26,15 @@
             
             <div class="control-group">
                 <h3>Encryption</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Symmetric Encryption</h4>
                     <p>Implement AES encryption for high-performance data protection.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Asymmetric Encryption</h4>
                     <p>Use RSA/ECC for key exchange and digital signatures.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Hybrid Encryption Systems</h4>
                     <p>Combine symmetric and asymmetric encryption for optimal security and performance.</p>
                 </div>
@@ -61,15 +42,15 @@
 
             <div class="control-group">
                 <h3>Hashing & Integrity</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Cryptographic Hash Functions</h4>
                     <p>Use SHA-256 or SHA-3 for data integrity verification.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Message Authentication Codes</h4>
                     <p>Implement HMAC for authenticated message integrity.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Digital Signatures</h4>
                     <p>Deploy digital signature schemes for non-repudiation.</p>
                 </div>
@@ -77,19 +58,19 @@
 
             <div class="control-group">
                 <h3>Key Management</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Key Generation</h4>
                     <p>Use cryptographically secure random number generators.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Key Storage</h4>
                     <p>Secure key storage using HSMs or secure key vaults.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Key Rotation</h4>
                     <p>Implement regular key rotation and lifecycle management.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Key Escrow</h4>
                     <p>Establish key recovery procedures for business continuity.</p>
                 </div>
@@ -97,15 +78,15 @@
 
             <div class="control-group">
                 <h3>PKI & Certificates</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Public Key Infrastructure</h4>
                     <p>Deploy PKI for certificate-based authentication and encryption.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Certificate Management</h4>
                     <p>Manage certificate lifecycle including issuance, renewal, and revocation.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Certificate Validation</h4>
                     <p>Implement proper certificate chain validation and CRL checking.</p>
                 </div>
@@ -113,11 +94,11 @@
 
             <div class="control-group">
                 <h3>Implementation Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure Coding Practices</h4>
                     <p>Avoid common cryptographic implementation vulnerabilities.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Side-Channel Attack Protection</h4>
                     <p>Implement countermeasures against timing and power analysis attacks.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/data-protection.html
+++ b/iron-codex-w3-w3schools-next/content/topics/data-protection.html
@@ -4,24 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Data Protection - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Data classification, DLP, privacy regulations (GDPR, CCPA), data governance, and backup security">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Data Protection</span>
@@ -40,15 +26,15 @@
             
             <div class="control-group">
                 <h3>Data Classification</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Classification Framework</h4>
                     <p>Establish systematic data classification based on sensitivity and business value.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Labeling</h4>
                     <p>Implement automated and manual data labeling mechanisms.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>PII Identification</h4>
                     <p>Identify and catalog personally identifiable information across systems.</p>
                 </div>
@@ -56,15 +42,15 @@
 
             <div class="control-group">
                 <h3>Data Loss Prevention</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>DLP Implementation</h4>
                     <p>Deploy data loss prevention solutions across endpoints, network, and cloud.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Content Inspection</h4>
                     <p>Implement deep content inspection for sensitive data patterns.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Exfiltration Prevention</h4>
                     <p>Prevent unauthorized data transmission and removal.</p>
                 </div>
@@ -72,19 +58,19 @@
 
             <div class="control-group">
                 <h3>Privacy Compliance</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>GDPR Compliance</h4>
                     <p>Implement General Data Protection Regulation requirements.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>CCPA Compliance</h4>
                     <p>Meet California Consumer Privacy Act obligations.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Privacy Impact Assessments</h4>
                     <p>Conduct privacy impact assessments for data processing activities.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Subject Rights</h4>
                     <p>Implement processes for data subject access, correction, and deletion requests.</p>
                 </div>
@@ -92,15 +78,15 @@
 
             <div class="control-group">
                 <h3>Data Governance</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Inventory</h4>
                     <p>Maintain comprehensive inventory of data assets and flows.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Lineage</h4>
                     <p>Track data movement and transformations across systems.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Retention Policies</h4>
                     <p>Implement and enforce data retention and disposal policies.</p>
                 </div>
@@ -108,23 +94,23 @@
 
             <div class="control-group">
                 <h3>Data Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Encryption at Rest</h4>
                     <p>Encrypt sensitive data stored in databases and file systems.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Encryption in Transit</h4>
                     <p>Protect data during transmission with strong encryption protocols.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Key Management</h4>
                     <p>Implement secure cryptographic key lifecycle management.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Access Controls</h4>
                     <p>Enforce role-based access controls for sensitive data.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Backup Security</h4>
                     <p>Secure backup data with encryption and access controls.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/devsecops.html
+++ b/iron-codex-w3-w3schools-next/content/topics/devsecops.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DevSecOps - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Security in CI/CD, SAST, DAST, infrastructure as code security, and shift-left practices">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>DevSecOps</span>
@@ -45,19 +26,19 @@
             
             <div class="control-group">
                 <h3>Pipeline Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure CI/CD Pipelines</h4>
                     <p>Implement security controls throughout CI/CD pipelines.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Static Code Analysis (SAST)</h4>
                     <p>Integrate static application security testing into build process.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Dynamic Testing (DAST)</h4>
                     <p>Perform runtime security testing of applications.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Dependency Scanning</h4>
                     <p>Scan third-party dependencies for known vulnerabilities.</p>
                 </div>
@@ -65,19 +46,19 @@
 
             <div class="control-group">
                 <h3>Code Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure Coding Standards</h4>
                     <p>Establish and enforce secure coding guidelines.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Code Review Security</h4>
                     <p>Include security focus in peer code reviews.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secret Management</h4>
                     <p>Secure handling of secrets and credentials in code.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>License Compliance</h4>
                     <p>Ensure compliance with open source license requirements.</p>
                 </div>
@@ -85,15 +66,15 @@
 
             <div class="control-group">
                 <h3>Infrastructure as Code</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>IaC Security Scanning</h4>
                     <p>Scan infrastructure code for security misconfigurations.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Templates</h4>
                     <p>Use pre-approved secure infrastructure templates.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Configuration Validation</h4>
                     <p>Validate infrastructure configurations against security policies.</p>
                 </div>
@@ -101,15 +82,15 @@
 
             <div class="control-group">
                 <h3>Container Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Container Image Scanning</h4>
                     <p>Scan container images for vulnerabilities and misconfigurations.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Registry Security</h4>
                     <p>Secure container registries and image distribution.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Runtime Protection</h4>
                     <p>Monitor containers at runtime for security threats.</p>
                 </div>
@@ -117,15 +98,15 @@
 
             <div class="control-group">
                 <h3>Monitoring & Response</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Monitoring</h4>
                     <p>Monitor applications and infrastructure for security events.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Incident Response</h4>
                     <p>Integrate incident response into DevOps workflows.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Compliance Automation</h4>
                     <p>Automate compliance checking and reporting.</p>
                 </div>
@@ -133,27 +114,27 @@
 
             <div class="control-group">
                 <h3>Culture & Training</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Training</h4>
                     <p>Provide security training for development teams.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Champions</h4>
                     <p>Establish security champion programs within teams.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Threat Modeling</h4>
                     <p>Integrate threat modeling into design processes.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Metrics</h4>
                     <p>Track and measure security performance in DevOps.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Feedback Loops</h4>
                     <p>Create feedback mechanisms for security improvements.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Policy as Code</h4>
                     <p>Implement security policies as code for automation.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/digital-forensics.html
+++ b/iron-codex-w3-w3schools-next/content/topics/digital-forensics.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Digital Forensics - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Evidence collection, chain of custody, forensic analysis, memory forensics, and legal considerations">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Digital Forensics</span>
@@ -46,20 +27,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>Evidence Acquisition</h4>
                         <p>Proper collection and preservation of digital evidence using forensically sound methods</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Chain of Custody</h4>
                         <p>Documented process ensuring evidence integrity from collection to court presentation</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Forensic Analysis</h4>
                         <p>Technical examination of digital artifacts using specialized tools and techniques</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Legal Compliance</h4>
                         <p>Adherence to legal requirements and standards for evidence admissibility</p>
                     </div>
@@ -73,7 +54,7 @@
             <div class="control-group">
                 <h3>Evidence Collection</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Forensic Imaging and Acquisition</h4>
                     <p>Create bit-by-bit copies of digital media using forensically sound methods.</p>
                     <div class="implementation-example">
@@ -87,22 +68,22 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Volatile Memory Acquisition</h4>
                     <p>Capture RAM contents and running processes before shutdown.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Mobile Device Forensics</h4>
                     <p>Extract data from smartphones, tablets, and other mobile devices.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Cloud Forensics</h4>
                     <p>Collect evidence from cloud services and virtualized environments.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Network Forensics</h4>
                     <p>Capture and analyze network traffic and communications.</p>
                 </div>
@@ -111,7 +92,7 @@
             <div class="control-group">
                 <h3>Chain of Custody</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Evidence Documentation</h4>
                     <p>Maintain detailed records of evidence handling and custody transfers.</p>
                     <div class="implementation-example">
@@ -125,12 +106,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure Evidence Storage</h4>
                     <p>Store evidence in controlled environments with access controls.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Evidence Tracking</h4>
                     <p>Implement systems to track evidence location and access history.</p>
                 </div>
@@ -139,27 +120,27 @@
             <div class="control-group">
                 <h3>Forensic Analysis</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>File System Analysis</h4>
                     <p>Examine file systems for deleted files, metadata, and artifacts.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Timeline Analysis</h4>
                     <p>Reconstruct chronological sequence of events from digital artifacts.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Registry Analysis</h4>
                     <p>Examine Windows registry for system and user activity evidence.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Log File Analysis</h4>
                     <p>Analyze system and application logs for forensic evidence.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Malware Analysis</h4>
                     <p>Analyze malicious software found during investigations.</p>
                 </div>
@@ -168,17 +149,17 @@
             <div class="control-group">
                 <h3>Specialized Forensics</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Database Forensics</h4>
                     <p>Examine database systems and transaction logs for evidence.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Email Forensics</h4>
                     <p>Analyze email systems and communications for investigation.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Browser Forensics</h4>
                     <p>Examine web browser artifacts including history and cache.</p>
                 </div>
@@ -187,17 +168,17 @@
             <div class="control-group">
                 <h3>Legal and Reporting</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Expert Reporting</h4>
                     <p>Prepare detailed forensic reports for legal proceedings.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Expert Testimony</h4>
                     <p>Provide expert witness testimony in legal proceedings.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Legal Compliance</h4>
                     <p>Ensure adherence to legal requirements and standards.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/email-security.html
+++ b/iron-codex-w3-w3schools-next/content/topics/email-security.html
@@ -4,24 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Email Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="SPF, DKIM, DMARC, phishing protection, email encryption, gateway security, and threat detection">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Email Security</span>
@@ -40,15 +26,15 @@
             
             <div class="control-group">
                 <h3>Email Authentication</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>SPF Implementation</h4>
                     <p>Configure Sender Policy Framework to prevent email spoofing.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>DKIM Signing</h4>
                     <p>Implement DomainKeys Identified Mail for email integrity verification.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>DMARC Policy</h4>
                     <p>Deploy Domain-based Message Authentication for comprehensive email authentication.</p>
                 </div>
@@ -56,19 +42,19 @@
 
             <div class="control-group">
                 <h3>Threat Protection</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Anti-Phishing</h4>
                     <p>Implement advanced phishing detection and prevention mechanisms.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Malware Scanning</h4>
                     <p>Scan email attachments and content for malware and viruses.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>URL Protection</h4>
                     <p>Analyze and protect against malicious URLs in emails.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Sandboxing</h4>
                     <p>Execute suspicious attachments in isolated environments.</p>
                 </div>
@@ -76,11 +62,11 @@
 
             <div class="control-group">
                 <h3>Encryption & Privacy</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>TLS Encryption</h4>
                     <p>Enforce TLS encryption for email transmission.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>End-to-End Encryption</h4>
                     <p>Implement S/MIME or PGP for sensitive email communications.</p>
                 </div>
@@ -88,19 +74,19 @@
 
             <div class="control-group">
                 <h3>Gateway & Filtering</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Email Gateway Security</h4>
                     <p>Deploy secure email gateways with comprehensive filtering.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Spam Filtering</h4>
                     <p>Implement effective spam detection and filtering mechanisms.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Content Filtering</h4>
                     <p>Filter email content based on policies and compliance requirements.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Loss Prevention</h4>
                     <p>Prevent sensitive data leakage through email communications.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/endpoint-security.html
+++ b/iron-codex-w3-w3schools-next/content/topics/endpoint-security.html
@@ -4,24 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Endpoint Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="EDR, antivirus, device encryption, patch management, endpoint hardening, and BYOD security">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Endpoint Security</span>
@@ -40,15 +26,15 @@
             
             <div class="control-group">
                 <h3>Endpoint Detection & Response</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>EDR Implementation</h4>
                     <p>Deploy endpoint detection and response solutions for threat hunting and incident response.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Behavioral Analysis</h4>
                     <p>Monitor endpoint behavior for suspicious activities and anomalies.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Threat Hunting</h4>
                     <p>Proactively hunt for threats across endpoints.</p>
                 </div>
@@ -56,15 +42,15 @@
 
             <div class="control-group">
                 <h3>Malware Protection</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Next-Generation Antivirus</h4>
                     <p>Implement advanced antivirus with machine learning and heuristics.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Anti-Malware</h4>
                     <p>Deploy comprehensive anti-malware protection.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Sandboxing</h4>
                     <p>Use sandboxing to analyze suspicious files and applications.</p>
                 </div>
@@ -72,15 +58,15 @@
 
             <div class="control-group">
                 <h3>Device Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Device Encryption</h4>
                     <p>Enforce full disk encryption on all endpoint devices.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure Boot</h4>
                     <p>Implement secure boot processes to prevent rootkits.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Device Hardening</h4>
                     <p>Apply security configurations and disable unnecessary services.</p>
                 </div>
@@ -88,15 +74,15 @@
 
             <div class="control-group">
                 <h3>Patch Management</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Automated Patching</h4>
                     <p>Implement automated patch management for operating systems and applications.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Vulnerability Assessment</h4>
                     <p>Regular vulnerability scanning and assessment of endpoints.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Patch Testing</h4>
                     <p>Test patches in controlled environments before deployment.</p>
                 </div>
@@ -104,19 +90,19 @@
 
             <div class="control-group">
                 <h3>Access Control</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>User Account Control</h4>
                     <p>Implement proper user privilege management and UAC.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Application Control</h4>
                     <p>Control which applications can execute on endpoints.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>USB and Removable Media Control</h4>
                     <p>Control and monitor removable media usage.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Network Access Control</h4>
                     <p>Control endpoint network access based on compliance and security posture.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/identity-access-management.html
+++ b/iron-codex-w3-w3schools-next/content/topics/identity-access-management.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Identity & Access Management - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="IAM architecture, RBAC, PBAC, SSO, MFA, privilege management, and identity governance">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Identity & Access Management</span>
@@ -45,19 +26,19 @@
             
             <div class="control-group">
                 <h3>Authentication</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Multi-Factor Authentication</h4>
                     <p>Implement MFA for all user accounts with multiple authentication factors.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Single Sign-On (SSO)</h4>
                     <p>Deploy enterprise SSO solution with SAML or OpenID Connect.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Adaptive Authentication</h4>
                     <p>Risk-based authentication based on user behavior and context.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Password Policies</h4>
                     <p>Enforce strong password requirements and regular rotation.</p>
                 </div>
@@ -65,19 +46,19 @@
 
             <div class="control-group">
                 <h3>Authorization</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Role-Based Access Control (RBAC)</h4>
                     <p>Implement hierarchical roles with proper inheritance and separation.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Attribute-Based Access Control (ABAC)</h4>
                     <p>Fine-grained access control based on attributes and policies.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Just-in-Time Access</h4>
                     <p>Temporary privilege elevation with approval workflows.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Least Privilege Enforcement</h4>
                     <p>Grant minimum necessary permissions for job functions.</p>
                 </div>
@@ -85,19 +66,19 @@
 
             <div class="control-group">
                 <h3>Identity Lifecycle</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>User Provisioning</h4>
                     <p>Automated user account creation and initial access assignment.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Access Reviews</h4>
                     <p>Regular review and recertification of user access rights.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Account Deprovisioning</h4>
                     <p>Timely removal of access when users leave or change roles.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Identity Synchronization</h4>
                     <p>Sync identities across multiple systems and directories.</p>
                 </div>
@@ -105,15 +86,15 @@
 
             <div class="control-group">
                 <h3>Privileged Access</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Privileged Account Management</h4>
                     <p>Secure management of administrative and service accounts.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Session Recording</h4>
                     <p>Record and monitor privileged user sessions for audit.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Emergency Access</h4>
                     <p>Break-glass procedures for emergency administrative access.</p>
                 </div>
@@ -121,23 +102,23 @@
 
             <div class="control-group">
                 <h3>Governance & Monitoring</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Identity Analytics</h4>
                     <p>Monitor user behavior and detect anomalous access patterns.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Audit Logging</h4>
                     <p>Comprehensive logging of all identity and access events.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Compliance Reporting</h4>
                     <p>Generate reports for regulatory compliance and audits.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Identity Federation</h4>
                     <p>Secure federation with external identity providers.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Policy Management</h4>
                     <p>Centralized management of access policies and rules.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/incident-response.html
+++ b/iron-codex-w3-w3schools-next/content/topics/incident-response.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Incident Response - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="SIEM, log analysis, forensics, containment procedures, and recovery planning">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Incident Response</span>
@@ -46,20 +27,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>Detection & Analysis</h4>
                         <p>SIEM systems, log analysis, and threat hunting for early incident detection</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Containment & Eradication</h4>
                         <p>Rapid response procedures to contain threats and remove malicious presence</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Recovery & Lessons Learned</h4>
                         <p>System restoration and post-incident analysis for continuous improvement</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Communication & Coordination</h4>
                         <p>Stakeholder communication and coordination with internal and external teams</p>
                     </div>
@@ -73,7 +54,7 @@
             <div class="control-group">
                 <h3>Preparation</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Incident Response Plan</h4>
                     <p>Develop comprehensive incident response procedures and playbooks.</p>
                     <div class="implementation-example">
@@ -87,12 +68,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Incident Response Team</h4>
                     <p>Establish and train dedicated incident response team members.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Tools and Resources</h4>
                     <p>Deploy and maintain incident response tools and forensic capabilities.</p>
                 </div>
@@ -101,7 +82,7 @@
             <div class="control-group">
                 <h3>Detection & Analysis</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Information and Event Management (SIEM)</h4>
                     <p>Implement SIEM for centralized log collection and correlation.</p>
                     <div class="implementation-example">
@@ -115,17 +96,17 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Intrusion Detection and Prevention</h4>
                     <p>Deploy network and host-based detection systems.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Log Analysis and Monitoring</h4>
                     <p>Implement comprehensive logging and monitoring capabilities.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Threat Hunting</h4>
                     <p>Proactively search for indicators of compromise and threats.</p>
                 </div>
@@ -134,17 +115,17 @@
             <div class="control-group">
                 <h3>Containment</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Incident Containment Procedures</h4>
                     <p>Implement rapid containment strategies to limit incident impact.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Network Isolation</h4>
                     <p>Quickly isolate affected systems and network segments.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Evidence Preservation</h4>
                     <p>Preserve digital evidence while containing the incident.</p>
                 </div>
@@ -153,17 +134,17 @@
             <div class="control-group">
                 <h3>Eradication & Recovery</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Threat Eradication</h4>
                     <p>Remove malware, close attack vectors, and eliminate threats.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>System Recovery</h4>
                     <p>Restore systems and services to normal operations.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Vulnerability Remediation</h4>
                     <p>Address vulnerabilities that allowed the incident to occur.</p>
                 </div>
@@ -172,22 +153,22 @@
             <div class="control-group">
                 <h3>Communication & Coordination</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Internal Communication</h4>
                     <p>Coordinate with internal stakeholders and leadership.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>External Communication</h4>
                     <p>Manage communication with customers, partners, and regulators.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Law Enforcement Coordination</h4>
                     <p>Coordinate with law enforcement and legal teams as appropriate.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Post-Incident Analysis</h4>
                     <p>Conduct lessons learned sessions and improve response procedures.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/mobile-security.html
+++ b/iron-codex-w3-w3schools-next/content/topics/mobile-security.html
@@ -4,24 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mobile Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Mobile device management, app security, BYOD policies, mobile threat defense, and secure development">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Mobile Security</span>
@@ -40,19 +26,19 @@
             
             <div class="control-group">
                 <h3>Device Management</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Mobile Device Management (MDM)</h4>
                     <p>Implement centralized management of mobile devices and policies.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Device Encryption</h4>
                     <p>Enforce full device encryption for data protection.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Remote Wipe Capabilities</h4>
                     <p>Enable remote device wiping for lost or stolen devices.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Jailbreak/Root Detection</h4>
                     <p>Detect and restrict compromised devices.</p>
                 </div>
@@ -60,19 +46,19 @@
 
             <div class="control-group">
                 <h3>Application Security</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>App Store Controls</h4>
                     <p>Restrict app installations to approved stores and applications.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Mobile App Security Testing</h4>
                     <p>Conduct security testing of mobile applications.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Runtime Application Protection</h4>
                     <p>Implement runtime protection for mobile applications.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Code Obfuscation</h4>
                     <p>Protect mobile app code from reverse engineering.</p>
                 </div>
@@ -80,15 +66,15 @@
 
             <div class="control-group">
                 <h3>Network & Communication</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>VPN Configuration</h4>
                     <p>Implement secure VPN access for mobile devices.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Certificate Pinning</h4>
                     <p>Pin SSL certificates to prevent man-in-the-middle attacks.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Public Wi-Fi Protection</h4>
                     <p>Protect against public Wi-Fi security risks.</p>
                 </div>
@@ -96,15 +82,15 @@
 
             <div class="control-group">
                 <h3>BYOD & Policies</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>BYOD Policy Implementation</h4>
                     <p>Establish comprehensive bring-your-own-device policies.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Containerization</h4>
                     <p>Separate corporate and personal data on devices.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Mobile Threat Defense</h4>
                     <p>Deploy mobile threat detection and response solutions.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/network-security.html
+++ b/iron-codex-w3-w3schools-next/content/topics/network-security.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Network Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Firewalls, VPNs, IDS/IPS systems, network segmentation, and secure protocol implementation">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Network Security</span>
@@ -46,20 +27,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>Perimeter Security</h4>
                         <p>Firewalls, DMZ, and network boundary protection mechanisms</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Network Segmentation</h4>
                         <p>VLANs, subnets, and micro-segmentation for isolation</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Traffic Monitoring</h4>
                         <p>IDS/IPS, network monitoring, and traffic analysis</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Secure Protocols</h4>
                         <p>VPNs, TLS/SSL, and encrypted communication channels</p>
                     </div>
@@ -73,7 +54,7 @@
             <div class="control-group">
                 <h3>Perimeter Defense</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Deploy Next-Generation Firewalls</h4>
                     <p>Implement advanced firewalls with deep packet inspection, application awareness, and threat intelligence integration.</p>
                     <div class="implementation-example">
@@ -87,17 +68,17 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Configure DMZ Architecture</h4>
                     <p>Establish demilitarized zones to isolate public-facing services from internal networks.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Network Access Control (NAC)</h4>
                     <p>Control device access to network resources based on device compliance and identity verification.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Deploy Web Application Firewalls</h4>
                     <p>Protect web applications from common attacks like SQL injection and XSS.</p>
                 </div>
@@ -106,7 +87,7 @@
             <div class="control-group">
                 <h3>Network Segmentation</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Network Segmentation</h4>
                     <p>Divide networks into smaller segments to limit attack spread and improve security monitoring.</p>
                     <div class="implementation-example">
@@ -120,12 +101,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Configure Access Control Lists (ACLs)</h4>
                     <p>Define and enforce network traffic rules at various network layers.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Network Isolation</h4>
                     <p>Separate critical systems and sensitive data networks from general user networks.</p>
                 </div>
@@ -134,22 +115,22 @@
             <div class="control-group">
                 <h3>Monitoring & Detection</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Deploy Intrusion Detection Systems (IDS)</h4>
                     <p>Monitor network traffic for suspicious activities and known attack patterns.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Network Traffic Analysis</h4>
                     <p>Continuously analyze network flows to detect anomalies and potential threats.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Configure SIEM Integration</h4>
                     <p>Integrate network security devices with SIEM for centralized monitoring and correlation.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Deploy Honeypots and Honeynets</h4>
                     <p>Use deception technology to detect and analyze attack methods.</p>
                 </div>
@@ -158,22 +139,22 @@
             <div class="control-group">
                 <h3>Secure Communications</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement VPN Solutions</h4>
                     <p>Provide secure remote access through encrypted tunnels and strong authentication.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Configure Network Encryption</h4>
                     <p>Encrypt sensitive network communications using strong cryptographic protocols.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure Wireless Networks</h4>
                     <p>Implement WPA3 encryption and proper wireless network segmentation.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Network Protocol Security</h4>
                     <p>Disable insecure protocols and implement secure alternatives.</p>
                 </div>
@@ -182,17 +163,17 @@
             <div class="control-group">
                 <h3>Network Management</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Network Device Hardening</h4>
                     <p>Secure network infrastructure devices with proper configuration and access controls.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Configure Network Redundancy</h4>
                     <p>Implement redundant network paths and failover mechanisms for availability.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Network Change Management</h4>
                     <p>Establish controlled processes for network configuration changes.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/physical-security.html
+++ b/iron-codex-w3-w3schools-next/content/topics/physical-security.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Physical Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Access controls, surveillance systems, environmental controls, facility security, and asset protection">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Physical Security</span>
@@ -46,20 +27,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>Access Control</h4>
                         <p>Badge systems, biometrics, and controlled entry points for facility access management</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Surveillance Systems</h4>
                         <p>CCTV monitoring, intrusion detection, and security monitoring systems</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Environmental Protection</h4>
                         <p>Fire suppression, climate control, and power protection systems</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Asset Protection</h4>
                         <p>Equipment security, data center protection, and mobile device management</p>
                     </div>
@@ -73,7 +54,7 @@
             <div class="control-group">
                 <h3>Facility Access Control</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Multi-Factor Access Control</h4>
                     <p>Deploy badge readers, PINs, and biometric systems for facility entry.</p>
                     <div class="implementation-example">
@@ -87,12 +68,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Guards and Reception</h4>
                     <p>Deploy trained security personnel for access control and monitoring.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Perimeter Security</h4>
                     <p>Implement fencing, barriers, and perimeter detection systems.</p>
                 </div>
@@ -101,7 +82,7 @@
             <div class="control-group">
                 <h3>Surveillance & Monitoring</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>CCTV Surveillance System</h4>
                     <p>Install comprehensive video surveillance with recording and monitoring capabilities.</p>
                     <div class="implementation-example">
@@ -115,12 +96,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Intrusion Detection Systems</h4>
                     <p>Deploy motion sensors, door/window alarms, and break-glass detectors.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Lighting</h4>
                     <p>Implement adequate lighting for all areas including motion-activated systems.</p>
                 </div>
@@ -129,17 +110,17 @@
             <div class="control-group">
                 <h3>Environmental Controls</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Fire Detection and Suppression</h4>
                     <p>Install fire detection systems and appropriate suppression mechanisms.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Climate Control</h4>
                     <p>Maintain appropriate temperature and humidity levels for equipment protection.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Power Protection</h4>
                     <p>Implement UPS systems, backup generators, and power monitoring.</p>
                 </div>
@@ -148,12 +129,12 @@
             <div class="control-group">
                 <h3>Asset Protection</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Equipment Security</h4>
                     <p>Secure computing equipment with locks, cables, and enclosures.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Clean Desk Policy</h4>
                     <p>Enforce policies for securing sensitive materials when not in use.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/red-team-operations.html
+++ b/iron-codex-w3-w3schools-next/content/topics/red-team-operations.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Red Team Operations - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Penetration testing, social engineering, adversary simulation, exploit development, and offensive security">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Red Team Operations</span>
@@ -48,20 +29,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>Penetration Testing</h4>
                         <p>Systematic testing of systems and applications to identify security vulnerabilities</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Social Engineering</h4>
                         <p>Human-based attack techniques to bypass security controls through psychological manipulation</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Adversary Simulation</h4>
                         <p>Emulating real-world threat actors and their attack methodologies</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Purple Team Collaboration</h4>
                         <p>Collaborative approach combining red team tactics with blue team defense</p>
                     </div>
@@ -75,7 +56,7 @@
             <div class="control-group">
                 <h3>Planning & Scoping</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Engagement Scoping and Rules</h4>
                     <p>Define clear scope, objectives, and rules of engagement for red team operations.</p>
                     <div class="implementation-example">
@@ -89,12 +70,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Threat Modeling</h4>
                     <p>Model specific threat actors and their tactics for realistic simulation.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Risk Assessment</h4>
                     <p>Assess potential risks of testing activities and implement safeguards.</p>
                 </div>
@@ -103,7 +84,7 @@
             <div class="control-group">
                 <h3>Reconnaissance</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Open Source Intelligence (OSINT)</h4>
                     <p>Gather intelligence from publicly available sources.</p>
                     <div class="implementation-example">
@@ -117,12 +98,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Network Reconnaissance</h4>
                     <p>Identify network topology, services, and potential entry points.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Social Engineering Reconnaissance</h4>
                     <p>Gather information about personnel and organizational structure.</p>
                 </div>
@@ -131,22 +112,22 @@
             <div class="control-group">
                 <h3>Initial Access</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>External Penetration Testing</h4>
                     <p>Test external-facing systems and applications for vulnerabilities.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Phishing Campaigns</h4>
                     <p>Conduct controlled phishing tests to assess user awareness.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Physical Security Testing</h4>
                     <p>Test physical security controls and access restrictions.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Wireless Network Testing</h4>
                     <p>Assess wireless network security and potential entry points.</p>
                 </div>
@@ -155,22 +136,22 @@
             <div class="control-group">
                 <h3>Post-Exploitation</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Privilege Escalation</h4>
                     <p>Test ability to escalate privileges within compromised systems.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Lateral Movement</h4>
                     <p>Assess network segmentation and internal security controls.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Persistence Mechanisms</h4>
                     <p>Test detection capabilities for persistence techniques.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Exfiltration Testing</h4>
                     <p>Simulate data theft to test data loss prevention controls.</p>
                 </div>
@@ -179,17 +160,17 @@
             <div class="control-group">
                 <h3>Social Engineering</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Pretexting Operations</h4>
                     <p>Test human defenses through fabricated scenarios and personas.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Vishing and Smishing</h4>
                     <p>Voice and SMS-based social engineering assessments.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Physical Social Engineering</h4>
                     <p>In-person social engineering and tailgating assessments.</p>
                 </div>
@@ -198,22 +179,22 @@
             <div class="control-group">
                 <h3>Advanced Techniques</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Custom Exploit Development</h4>
                     <p>Develop custom exploits for identified vulnerabilities.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Evasion Techniques</h4>
                     <p>Test security controls' ability to detect advanced evasion.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Living off the Land</h4>
                     <p>Use legitimate tools and processes for malicious purposes.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Supply Chain Testing</h4>
                     <p>Assess third-party and supply chain security risks.</p>
                 </div>
@@ -222,17 +203,17 @@
             <div class="control-group">
                 <h3>Testing Methodology</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Adversary Emulation</h4>
                     <p>Emulate specific threat actor behaviors and techniques.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Purple Team Exercises</h4>
                     <p>Collaborative testing with defensive teams for improvement.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Tabletop Exercises</h4>
                     <p>Scenario-based discussion exercises for incident response.</p>
                 </div>
@@ -241,17 +222,17 @@
             <div class="control-group">
                 <h3>Reporting & Remediation</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Comprehensive Reporting</h4>
                     <p>Document findings with actionable remediation guidance.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Executive Briefings</h4>
                     <p>Present strategic insights to executive leadership.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Remediation Validation</h4>
                     <p>Re-test systems after remediation to verify fixes.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/security-awareness.html
+++ b/iron-codex-w3-w3schools-next/content/topics/security-awareness.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Security Awareness - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Security training, phishing simulation, social engineering defense, and human risk management">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Security Awareness</span>
@@ -48,20 +29,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>Human Risk Management</h4>
                         <p>Understanding and mitigating risks posed by human behavior and decision-making in security contexts</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Phishing Defense</h4>
                         <p>Training employees to recognize and respond to phishing and social engineering attacks</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Security Culture</h4>
                         <p>Building an organizational culture where security is everyone's responsibility</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Behavioral Change</h4>
                         <p>Using psychology and behavioral science to drive lasting security behavior changes</p>
                     </div>
@@ -74,7 +55,7 @@
             
             <div class="control-group">
                 <h3>Training & Education</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Awareness Training Program</h4>
                     <p>Implement comprehensive security awareness training for all employees.</p>
                     <div class="implementation-example">
@@ -87,15 +68,15 @@
                         </ul>
                     </div>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Role-Based Security Training</h4>
                     <p>Deliver targeted training based on employee roles and responsibilities.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>New Employee Security Orientation</h4>
                     <p>Provide security training as part of employee onboarding process.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Regular Training Updates</h4>
                     <p>Maintain current training content reflecting latest threats and policies.</p>
                 </div>
@@ -103,7 +84,7 @@
 
             <div class="control-group">
                 <h3>Phishing & Social Engineering</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Phishing Simulation Programs</h4>
                     <p>Conduct regular simulated phishing attacks to test and train employees.</p>
                     <div class="implementation-example">
@@ -116,11 +97,11 @@
                         </ul>
                     </div>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Social Engineering Awareness</h4>
                     <p>Educate employees about social engineering tactics and defenses.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Incident Reporting Training</h4>
                     <p>Train employees on how to recognize and report security incidents.</p>
                 </div>
@@ -128,15 +109,15 @@
 
             <div class="control-group">
                 <h3>Culture & Metrics</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Culture Development</h4>
                     <p>Foster a culture of security awareness and responsibility.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Awareness Program Metrics</h4>
                     <p>Track and measure effectiveness of security awareness programs.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Communication Campaigns</h4>
                     <p>Deploy ongoing security communication and awareness campaigns.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/security-fundamentals.html
+++ b/iron-codex-w3-w3schools-next/content/topics/security-fundamentals.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Security Fundamentals - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Core security principles, CIA triad, risk management, compliance frameworks, and security governance basics">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Security Fundamentals</span>
@@ -46,20 +27,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>CIA Triad</h4>
                         <p>Confidentiality, Integrity, and Availability - the three pillars of information security</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Risk Management</h4>
                         <p>Identifying, assessing, and mitigating security risks in business context</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Security Frameworks</h4>
                         <p>NIST CSF, ISO 27001, and other industry-standard security frameworks</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Governance & Compliance</h4>
                         <p>Security policies, procedures, and regulatory compliance requirements</p>
                     </div>
@@ -73,7 +54,7 @@
             <div class="control-group">
                 <h3>Core Security Principles</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement CIA Triad Framework</h4>
                     <p>Establish confidentiality, integrity, and availability as core security objectives for all systems and data.</p>
                     <div class="implementation-example">
@@ -86,7 +67,7 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Apply Defense in Depth Strategy</h4>
                     <p>Implement multiple layers of security controls to create comprehensive protection.</p>
                     <div class="implementation-example">
@@ -100,7 +81,7 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Establish Least Privilege Principle</h4>
                     <p>Grant users and systems the minimum level of access required to perform their functions.</p>
                     <div class="implementation-example">
@@ -113,7 +94,7 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Security by Design</h4>
                     <p>Integrate security considerations into all phases of system development and deployment.</p>
                     <div class="implementation-example">
@@ -131,7 +112,7 @@
             <div class="control-group">
                 <h3>Risk Management</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Conduct Risk Assessments</h4>
                     <p>Regularly identify, analyze, and evaluate security risks to organizational assets.</p>
                     <div class="implementation-example">
@@ -145,12 +126,12 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Develop Risk Treatment Plans</h4>
                     <p>Create and implement strategies to address identified risks through mitigation, transfer, acceptance, or avoidance.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Establish Risk Monitoring</h4>
                     <p>Continuously monitor risk levels and the effectiveness of implemented controls.</p>
                 </div>
@@ -159,7 +140,7 @@
             <div class="control-group">
                 <h3>Governance & Compliance</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Develop Security Policies</h4>
                     <p>Create comprehensive security policies that align with business objectives and regulatory requirements.</p>
                     <div class="implementation-example">
@@ -173,22 +154,22 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Security Awareness Training</h4>
                     <p>Educate employees on security policies, procedures, and best practices.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Establish Compliance Framework</h4>
                     <p>Align security practices with relevant regulatory requirements and industry standards.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Conduct Security Audits</h4>
                     <p>Regularly assess the effectiveness of security controls and compliance with policies.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Manage Security Metrics</h4>
                     <p>Define and track key security metrics to measure program effectiveness.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/threat-intelligence.html
+++ b/iron-codex-w3-w3schools-next/content/topics/threat-intelligence.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Threat Intelligence - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Threat hunting, IOCs, TTPs, MITRE ATT&CK, threat modeling, and intelligence sharing platforms">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Threat Intelligence</span>
@@ -45,19 +26,19 @@
             
             <div class="control-group">
                 <h3>Threat Intelligence Collection</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Intelligence Sources</h4>
                     <p>Establish multiple threat intelligence feeds and sources.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>IOC Management</h4>
                     <p>Collect and manage indicators of compromise effectively.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>TTP Analysis</h4>
                     <p>Analyze tactics, techniques, and procedures of threat actors.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>MITRE ATT&CK Framework</h4>
                     <p>Use MITRE ATT&CK for threat modeling and detection.</p>
                 </div>
@@ -65,15 +46,15 @@
 
             <div class="control-group">
                 <h3>Threat Hunting</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Proactive Hunting</h4>
                     <p>Actively search for threats within the environment.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Hypothesis-Driven Hunting</h4>
                     <p>Develop and test threat hypotheses systematically.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Behavioral Analysis</h4>
                     <p>Analyze user and system behavior for anomalies.</p>
                 </div>
@@ -81,15 +62,15 @@
 
             <div class="control-group">
                 <h3>Intelligence Analysis</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Threat Attribution</h4>
                     <p>Identify and attribute threats to specific threat actors.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Campaign Tracking</h4>
                     <p>Track and monitor threat campaign activities.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Risk Assessment</h4>
                     <p>Assess threat risk levels and potential impact.</p>
                 </div>
@@ -97,15 +78,15 @@
 
             <div class="control-group">
                 <h3>Intelligence Sharing</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Information Sharing</h4>
                     <p>Share threat intelligence with relevant stakeholders.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>STIX/TAXII Implementation</h4>
                     <p>Use structured threat information exchange standards.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Industry Collaboration</h4>
                     <p>Participate in industry threat sharing initiatives.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/web-application-security.html
+++ b/iron-codex-w3-w3schools-next/content/topics/web-application-security.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Web Application Security - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="OWASP Top 10, input validation, session management, secure coding practices, and application testing">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Web Application Security</span>
@@ -46,20 +27,20 @@
             
             <div class="key-concepts">
                 <h3>Key Concepts Covered</h3>
-                <div class="concepts-grid">
-                    <div class="concept-card">
+                <div class="w3-row">
+                    <div class="w3-col">
                         <h4>OWASP Top 10</h4>
                         <p>Most critical web application security risks and mitigation strategies</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Input Validation</h4>
                         <p>Comprehensive input sanitization and validation techniques</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Session Management</h4>
                         <p>Secure session handling and state management</p>
                     </div>
-                    <div class="concept-card">
+                    <div class="w3-col">
                         <h4>Secure Coding</h4>
                         <p>Best practices for writing secure application code</p>
                     </div>
@@ -73,7 +54,7 @@
             <div class="control-group">
                 <h3>Input Validation & Sanitization</h3>
                 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Comprehensive Input Validation</h4>
                     <p>Validate all user inputs on both client and server side using whitelist validation where possible.</p>
                     <div class="implementation-example">
@@ -87,17 +68,17 @@
                     </div>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Prevent SQL Injection</h4>
                     <p>Use parameterized queries, stored procedures, and input validation to prevent SQL injection attacks.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Prevent Cross-Site Scripting (XSS)</h4>
                     <p>Implement proper output encoding and Content Security Policy to prevent XSS attacks.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement CSRF Protection</h4>
                     <p>Use anti-CSRF tokens and proper HTTP methods to prevent cross-site request forgery.</p>
                 </div>
@@ -106,22 +87,22 @@
             <div class="control-group">
                 <h3>Authentication & Authorization</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Strong Authentication</h4>
                     <p>Deploy multi-factor authentication and strong password policies.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure Session Management</h4>
                     <p>Implement secure session handling with proper timeout and invalidation.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Role-Based Access Control</h4>
                     <p>Implement proper authorization checks for all application functions and resources.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Prevent Privilege Escalation</h4>
                     <p>Ensure users cannot access functions or data beyond their authorization level.</p>
                 </div>
@@ -130,22 +111,22 @@
             <div class="control-group">
                 <h3>Data Protection</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Implement Data Encryption</h4>
                     <p>Encrypt sensitive data both in transit and at rest using strong encryption algorithms.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure Data Storage</h4>
                     <p>Implement proper database security and avoid storing sensitive data unnecessarily.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Loss Prevention</h4>
                     <p>Implement controls to prevent unauthorized data exfiltration.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure File Handling</h4>
                     <p>Implement secure file upload, download, and processing mechanisms.</p>
                 </div>
@@ -154,22 +135,22 @@
             <div class="control-group">
                 <h3>Application Security</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Headers Configuration</h4>
                     <p>Implement security headers like HSTS, CSP, X-Frame-Options, and others.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Error Handling & Logging</h4>
                     <p>Implement proper error handling that doesn't leak sensitive information.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Rate Limiting & DoS Protection</h4>
                     <p>Implement rate limiting to prevent abuse and denial of service attacks.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Secure Configuration Management</h4>
                     <p>Ensure application and server configurations follow security best practices.</p>
                 </div>
@@ -178,32 +159,32 @@
             <div class="control-group">
                 <h3>Testing & Validation</h3>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Static Application Security Testing (SAST)</h4>
                     <p>Implement automated static code analysis to identify security vulnerabilities.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Dynamic Application Security Testing (DAST)</h4>
                     <p>Perform runtime security testing of applications in production-like environments.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Interactive Application Security Testing (IAST)</h4>
                     <p>Combine static and dynamic testing approaches for comprehensive coverage.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Penetration Testing</h4>
                     <p>Regular manual security testing by qualified security professionals.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Security Code Review</h4>
                     <p>Manual review of application code for security vulnerabilities and best practices.</p>
                 </div>
 
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Dependency Scanning</h4>
                     <p>Regular scanning of third-party components and libraries for known vulnerabilities.</p>
                 </div>

--- a/iron-codex-w3-w3schools-next/content/topics/zero-trust.html
+++ b/iron-codex-w3-w3schools-next/content/topics/zero-trust.html
@@ -4,29 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Zero Trust Architecture - Iron Codex</title>
-    <link rel="stylesheet" href="../assets/css/main.css">
     <meta name="description" content="Zero trust principles, micro-segmentation, continuous verification, and trust boundary elimination">
 </head>
 <body data-page="topic">
-    <header class="header">
-        <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
-            <ul class="nav-menu">
-                <li><a href="../index.html" class="nav-link">Home</a></li>
-                <li><a href="../topics.html" class="nav-link active">Topics</a></li>
-                <li><a href="../guides.html" class="nav-link">Guides</a></li>
-                <li><a href="../tools.html" class="nav-link">Tools</a></li>
-                <li><a href="../about.html" class="nav-link">About</a></li>
-            </ul>
-            <div class="nav-toggle" id="navToggle">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </nav>
-    </header>
-
-    <main class="container topic-content">
+    <main class="w3-container">
         <section class="topic-header">
             <nav class="breadcrumb">
                 <a href="../topics.html">Topics</a> / <span>Zero Trust Architecture</span>
@@ -45,15 +26,15 @@
             
             <div class="control-group">
                 <h3>Core Principles</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Never Trust, Always Verify</h4>
                     <p>Verify every user and device before granting access to resources.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Least Privilege Access</h4>
                     <p>Grant minimum necessary access for specific tasks and resources.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Assume Breach</h4>
                     <p>Design security assuming attackers are already inside the network.</p>
                 </div>
@@ -61,15 +42,15 @@
 
             <div class="control-group">
                 <h3>Network Architecture</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Micro-Segmentation</h4>
                     <p>Create granular network zones with strict access controls.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Software-Defined Perimeter</h4>
                     <p>Implement dynamic, encrypted tunnels for resource access.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Network Access Control</h4>
                     <p>Control device access based on identity, compliance, and trust level.</p>
                 </div>
@@ -77,15 +58,15 @@
 
             <div class="control-group">
                 <h3>Identity & Access</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Identity-Centric Security</h4>
                     <p>Make identity the primary security control point.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Continuous Authentication</h4>
                     <p>Continuously verify user and device identity during sessions.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Conditional Access</h4>
                     <p>Apply access policies based on risk and context.</p>
                 </div>
@@ -93,15 +74,15 @@
 
             <div class="control-group">
                 <h3>Data Protection</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data-Centric Security</h4>
                     <p>Protect data regardless of location or access method.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Encryption Everywhere</h4>
                     <p>Encrypt data in transit, at rest, and in use.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Data Classification</h4>
                     <p>Classify and label data for appropriate protection levels.</p>
                 </div>
@@ -109,19 +90,19 @@
 
             <div class="control-group">
                 <h3>Monitoring & Analytics</h3>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Behavioral Analytics</h4>
                     <p>Monitor user and entity behavior for anomaly detection.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Risk-Based Decisions</h4>
                     <p>Make access decisions based on real-time risk assessment.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Comprehensive Logging</h4>
                     <p>Log all access requests and security events for analysis.</p>
                 </div>
-                <div class="control-item">
+                <div class="w3-panel">
                     <h4>Automated Response</h4>
                     <p>Automatically respond to security threats and policy violations.</p>
                 </div>


### PR DESCRIPTION
## Summary
- drop legacy stylesheet imports and nav headers from guide/topic HTML
- convert main sections to `w3-container` with grid and panel classes
- wrap code samples with `w3-example` and `w3-code`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt prevents execution)*

------
https://chatgpt.com/codex/tasks/task_e_68c04a0d76e48322a6b9e248072c5499