### PR TITLE
Load home page content from structured JSON

### DIFF
--- a/iron-codex-w3-w3schools-next/app/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/page.tsx
@@ -1,8 +1,8 @@
-// Replace your current app/page.tsx with this to use the new landing.
-'use client';
-import React from "react";
 import HomeLanding from "@/components/HomeLanding";
+import { loadHome } from "@/lib/loadHome";
 
-export default function Page() {
-  return <HomeLanding />;
+export default async function Page() {
+  const homeContent = loadHome();
+
+  return <HomeLanding content={homeContent} />;
 }

--- a/iron-codex-w3-w3schools-next/components/HomeLanding.tsx
+++ b/iron-codex-w3-w3schools-next/components/HomeLanding.tsx
@@ -1,105 +1,72 @@
-'use client';
-import React from "react";
 import Link from "next/link";
 
-/** Iron Codex Landing (clean, W3-style utility-first, less flashy)
- *  - Hero with primary search
- *  - Quick Access tiles
- *  - Topic index sections (match secondary bar)
- *  - Tools spotlight
- */
+import type { HomeContent } from "@/schemas/home";
 
-const quickLinks: { label: string; href: string; k: string }[] = [
-  { label: "Security Fundamentals", href: "/topics/security-fundamentals", k: "fundamentals" },
-  { label: "AppSec", href: "/topics/appsec", k: "appsec" },
-  { label: "API Security", href: "/guides/api-security", k: "api" },
-  { label: "Cloud Security", href: "/topics/cloud-security", k: "cloud" },
-  { label: "Network Security", href: "/topics/network-security", k: "network" },
-  { label: "Identity & Access", href: "/topics/identity-access", k: "iam" },
-];
+type HomeLandingProps = {
+  content: HomeContent;
+};
 
-const topicBuckets: { title: string; items: { label: string; href: string }[] }[] = [
-  {
-    title: "Fundamentals",
-    items: [
-      { label: "Security Fundamentals", href: "/topics/security-fundamentals" },
-      { label: "Identity & Access", href: "/topics/identity-access" },
-      { label: "Cryptography", href: "/topics/cryptography" },
-      { label: "Risk Management", href: "/topics/risk-management" },
-    ],
-  },
-  {
-    title: "Network & Infra",
-    items: [
-      { label: "Network Security", href: "/topics/network-security" },
-      { label: "Cloud Security", href: "/topics/cloud-security" },
-      { label: "Endpoint Security", href: "/topics/endpoints" },
-      { label: "Supply Chain", href: "/topics/supply-chain" },
-    ],
-  },
-  {
-    title: "AppSec",
-    items: [
-      { label: "Application Security", href: "/topics/appsec" },
-      { label: "API Security", href: "/topics/api-security" },
-      { label: "Threat Modeling", href: "/topics/threat-modeling" },
-      { label: "Vulnerability Mgmt", href: "/topics/vuln-management" },
-    ],
-  },
-  {
-    title: "Governance",
-    items: [
-      { label: "RMF / NIST 800-53", href: "/topics/rmf-800-53" },
-      { label: "ISO 27001", href: "/topics/iso-27001" },
-      { label: "SOC 2", href: "/topics/soc2" },
-      { label: "FedRAMP", href: "/topics/fedramp" },
-    ],
-  },
-];
+export default function HomeLanding({ content }: HomeLandingProps) {
+  const { hero, quickLinks, topicBuckets, toolSpotlight } = content;
 
-const toolsSpotlight = [
-  { label: "Nmap", href: "/tools/nmap" },
-  { label: "Burp Suite", href: "/tools/burp-suite" },
-  { label: "Wireshark", href: "/tools/wireshark" },
-  { label: "Trivy", href: "/tools/trivy" },
-  { label: "Prowler", href: "/tools/prowler" },
-  { label: "HashiCorp Vault", href: "/tools/vault" },
-];
-
-export default function HomeLanding() {
   return (
     <main id="main" className="min-h-screen bg-slate-950 text-slate-100">
       {/* Hero */}
       <section className="border-b border-slate-800 bg-gradient-to-b from-slate-900 to-slate-950">
         <div className="mx-auto max-w-6xl px-4 py-14 md:py-20">
-          <div className="flex items-start md:items-center justify-between gap-8 flex-col md:flex-row">
+          <div className="flex flex-col items-start justify-between gap-8 md:flex-row md:items-center">
             <div className="max-w-2xl">
-              <h1 className="text-3xl md:text-4xl font-bold tracking-tight">
-                Iron Codex — Practical Cybersecurity Knowledge
-              </h1>
-              <p className="mt-3 text-slate-300">
-                Concise, actionable references. W3Schools structure. Security depth.
-              </p>
-              <form action="/topics" role="search" className="mt-6 flex w-full max-w-xl gap-2">
+              <h1 className="text-3xl font-bold tracking-tight md:text-4xl">{hero.title}</h1>
+              <p className="mt-3 text-slate-300">{hero.subtitle}</p>
+              <form action={hero.search.action} role="search" className="mt-6 flex w-full max-w-xl gap-2">
                 <input
                   name="q"
                   type="search"
                   aria-label="Search Iron Codex"
-                  placeholder="Search topics, guides, tools"
-                  className="h-11 flex-1 rounded-md border border-slate-700 bg-slate-900 px-3 text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 focus:border-emerald-500"
+                  placeholder={hero.search.placeholder}
+                  className="h-11 flex-1 rounded-md border border-slate-700 bg-slate-900 px-3 text-slate-100 placeholder-slate-500 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
                 />
-                <button className="h-11 px-4 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white">
-                  Search
+                <button className="h-11 rounded-md bg-emerald-600 px-4 text-white hover:bg-emerald-700">
+                  {hero.search.buttonLabel}
                 </button>
               </form>
+              <div className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3">
+                {hero.stats.map((stat) => {
+                  const body = (
+                    <>
+                      <p className="text-xs font-medium uppercase tracking-wide text-slate-400">{stat.label}</p>
+                      <p className="text-2xl font-semibold text-slate-100">
+                        {stat.value.toLocaleString("en-US")}
+                      </p>
+                    </>
+                  );
+
+                  return stat.href ? (
+                    <Link
+                      key={stat.key}
+                      href={stat.href}
+                      className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 transition hover:border-emerald-600 hover:text-emerald-400"
+                    >
+                      {body}
+                    </Link>
+                  ) : (
+                    <div
+                      key={stat.key}
+                      className="rounded-lg border border-slate-800 bg-slate-900/60 p-4"
+                    >
+                      {body}
+                    </div>
+                  );
+                })}
+              </div>
             </div>
             <div className="w-full md:w-auto">
-              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                 {quickLinks.map((q) => (
                   <Link
-                    key={q.k}
+                    key={q.key}
                     href={q.href}
-                    className="rounded-xl border border-slate-800 bg-slate-900 hover:bg-slate-800 px-4 py-3 text-slate-100 hover:text-emerald-400 transition text-sm text-center"
+                    className="rounded-xl border border-slate-800 bg-slate-900 px-4 py-3 text-center text-sm text-slate-100 transition hover:border-emerald-600 hover:bg-slate-800 hover:text-emerald-400"
                   >
                     {q.label}
                   </Link>
@@ -112,16 +79,16 @@ export default function HomeLanding() {
 
       {/* Topics index */}
       <section className="mx-auto max-w-6xl px-4 py-12 md:py-16">
-        <h2 className="text-xl font-semibold mb-6">Browse Topics</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
-          {topicBuckets.map((b) => (
-            <div key={b.title} className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
-              <h3 className="text-sm uppercase tracking-wide text-emerald-400 mb-2">{b.title}</h3>
+        <h2 className="mb-6 text-xl font-semibold">Browse Topics</h2>
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-4">
+          {topicBuckets.map((bucket) => (
+            <div key={bucket.title} className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+              <h3 className="mb-2 text-sm uppercase tracking-wide text-emerald-400">{bucket.title}</h3>
               <ul className="space-y-1 text-sm">
-                {b.items.map((it) => (
-                  <li key={it.href}>
-                    <Link href={it.href} className="text-slate-200 hover:text-emerald-400">
-                      {it.label}
+                {bucket.items.map((item) => (
+                  <li key={item.href}>
+                    <Link href={item.href} className="text-slate-200 hover:text-emerald-400">
+                      {item.label}
                     </Link>
                   </li>
                 ))}
@@ -134,20 +101,20 @@ export default function HomeLanding() {
       {/* Tools spotlight */}
       <section className="border-y border-slate-800 bg-slate-900/40">
         <div className="mx-auto max-w-6xl px-4 py-12 md:py-16">
-          <div className="flex items-center justify-between mb-6">
+          <div className="mb-6 flex items-center justify-between">
             <h2 className="text-xl font-semibold">Popular Tools</h2>
-            <Link href="/tools" className="text-sm text-emerald-400 hover:underline underline-offset-4">
+            <Link href="/tools" className="text-sm text-emerald-400 underline-offset-4 hover:underline">
               View all
             </Link>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
-            {toolsSpotlight.map((t) => (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-6">
+            {toolSpotlight.map((tool) => (
               <Link
-                key={t.href}
-                href={t.href}
-                className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-center text-slate-200 hover:text-emerald-400 hover:border-emerald-600 transition text-sm"
+                key={tool.href}
+                href={tool.href}
+                className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-center text-sm text-slate-200 transition hover:border-emerald-600 hover:text-emerald-400"
               >
-                {t.label}
+                {tool.label}
               </Link>
             ))}
           </div>

--- a/iron-codex-w3-w3schools-next/content/home.json
+++ b/iron-codex-w3-w3schools-next/content/home.json
@@ -1,0 +1,72 @@
+{
+  "hero": {
+    "title": "Iron Codex — Practical Cybersecurity Knowledge",
+    "subtitle": "Concise, actionable references. W3Schools structure. Security depth.",
+    "search": {
+      "action": "/topics",
+      "placeholder": "Search topics, guides, tools",
+      "buttonLabel": "Search"
+    },
+    "stats": [
+      { "label": "Topics", "key": "topics_count", "href": "/topics" },
+      { "label": "Controls", "key": "controls_count", "href": "/controls" },
+      { "label": "Guides", "key": "guides_count", "href": "/guides" },
+      { "label": "Examples", "key": "examples_count", "href": "/examples" },
+      { "label": "Resources", "key": "resources_count", "href": "/resources" }
+    ]
+  },
+  "quickLinks": [
+    { "label": "Security Fundamentals", "href": "/topics/security-fundamentals", "key": "fundamentals" },
+    { "label": "AppSec", "href": "/topics/appsec", "key": "appsec" },
+    { "label": "API Security", "href": "/guides/api-security", "key": "api" },
+    { "label": "Cloud Security", "href": "/topics/cloud-security", "key": "cloud" },
+    { "label": "Network Security", "href": "/topics/network-security", "key": "network" },
+    { "label": "Identity & Access", "href": "/topics/identity-access", "key": "iam" }
+  ],
+  "topicBuckets": [
+    {
+      "title": "Fundamentals",
+      "items": [
+        { "label": "Security Fundamentals", "href": "/topics/security-fundamentals" },
+        { "label": "Identity & Access", "href": "/topics/identity-access" },
+        { "label": "Cryptography", "href": "/topics/cryptography" },
+        { "label": "Risk Management", "href": "/topics/risk-management" }
+      ]
+    },
+    {
+      "title": "Network & Infra",
+      "items": [
+        { "label": "Network Security", "href": "/topics/network-security" },
+        { "label": "Cloud Security", "href": "/topics/cloud-security" },
+        { "label": "Endpoint Security", "href": "/topics/endpoints" },
+        { "label": "Supply Chain", "href": "/topics/supply-chain" }
+      ]
+    },
+    {
+      "title": "AppSec",
+      "items": [
+        { "label": "Application Security", "href": "/topics/appsec" },
+        { "label": "API Security", "href": "/topics/api-security" },
+        { "label": "Threat Modeling", "href": "/topics/threat-modeling" },
+        { "label": "Vulnerability Mgmt", "href": "/topics/vuln-management" }
+      ]
+    },
+    {
+      "title": "Governance",
+      "items": [
+        { "label": "RMF / NIST 800-53", "href": "/topics/rmf-800-53" },
+        { "label": "ISO 27001", "href": "/topics/iso-27001" },
+        { "label": "SOC 2", "href": "/topics/soc2" },
+        { "label": "FedRAMP", "href": "/topics/fedramp" }
+      ]
+    }
+  ],
+  "toolSpotlight": [
+    { "label": "Nmap", "href": "/tools/nmap" },
+    { "label": "Burp Suite", "href": "/tools/burp-suite" },
+    { "label": "Wireshark", "href": "/tools/wireshark" },
+    { "label": "Trivy", "href": "/tools/trivy" },
+    { "label": "Prowler", "href": "/tools/prowler" },
+    { "label": "HashiCorp Vault", "href": "/tools/vault" }
+  ]
+}

--- a/iron-codex-w3-w3schools-next/lib/loadHome.ts
+++ b/iron-codex-w3-w3schools-next/lib/loadHome.ts
@@ -1,0 +1,36 @@
+import fs from "fs";
+import path from "path";
+import { z } from "zod";
+
+import { HomeSchema, type HomeContent } from "@/schemas/home";
+
+const IndexStatsSchema = z.object({
+  topics_count: z.number(),
+  controls_count: z.number(),
+  guides_count: z.number(),
+  examples_count: z.number(),
+  resources_count: z.number()
+});
+
+export function loadHome(): HomeContent {
+  const homePath = path.join(process.cwd(), "content", "home.json");
+  const homeRaw = fs.readFileSync(homePath, "utf-8");
+  const homeData = HomeSchema.parse(JSON.parse(homeRaw));
+
+  const indexPath = path.join(process.cwd(), "content", "index.json");
+  const indexRaw = fs.readFileSync(indexPath, "utf-8");
+  const indexData = IndexStatsSchema.parse(JSON.parse(indexRaw));
+
+  const stats = homeData.hero.stats.map((stat) => ({
+    ...stat,
+    value: indexData[stat.key]
+  }));
+
+  return {
+    ...homeData,
+    hero: {
+      ...homeData.hero,
+      stats
+    }
+  };
+}

--- a/iron-codex-w3-w3schools-next/schemas/home.ts
+++ b/iron-codex-w3-w3schools-next/schemas/home.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+export const heroStatKeys = [
+  "topics_count",
+  "controls_count",
+  "guides_count",
+  "examples_count",
+  "resources_count"
+] as const;
+
+const HeroStatKeySchema = z.enum(heroStatKeys);
+
+const HeroStatSchema = z.object({
+  label: z.string(),
+  key: HeroStatKeySchema,
+  href: z.string().optional()
+});
+
+const QuickLinkSchema = z.object({
+  label: z.string(),
+  href: z.string(),
+  key: z.string()
+});
+
+const TopicBucketSchema = z.object({
+  title: z.string(),
+  items: z.array(z.object({ label: z.string(), href: z.string() }))
+});
+
+const ToolSpotlightSchema = z.object({
+  label: z.string(),
+  href: z.string()
+});
+
+export const HomeSchema = z.object({
+  hero: z.object({
+    title: z.string(),
+    subtitle: z.string(),
+    search: z.object({
+      action: z.string(),
+      placeholder: z.string(),
+      buttonLabel: z.string()
+    }),
+    stats: z.array(HeroStatSchema)
+  }),
+  quickLinks: z.array(QuickLinkSchema),
+  topicBuckets: z.array(TopicBucketSchema),
+  toolSpotlight: z.array(ToolSpotlightSchema)
+});
+
+export type HomeFile = z.infer<typeof HomeSchema>;
+export type HeroStatKey = z.infer<typeof HeroStatKeySchema>;
+export type HeroStat = HomeFile["hero"]["stats"][number] & { value: number };
+export type HomeContent = Omit<HomeFile, "hero"> & {
+  hero: Omit<HomeFile["hero"], "stats"> & { stats: HeroStat[] };
+};


### PR DESCRIPTION
## Summary
- add a structured `content/home.json` file that defines hero messaging, navigation tiles, topic buckets, and tool spotlights
- introduce a Zod schema and `loadHome` helper to parse the home content and merge hero stats from `content/index.json`
- refactor `HomeLanding` to accept typed content and update `app/page.tsx` to fetch the data on the server

## Testing
- not run (`npm run lint` prompts for interactive ESLint setup in this repo)


------
https://chatgpt.com/codex/tasks/task_e_68ce17f75df4832297c9c9b97f76248c