### PR TITLE
Update topic slugs to current routes

### DIFF
--- a/iron-codex-w3-w3schools-next/app/topics/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/page.tsx
@@ -21,7 +21,7 @@ const allTopics = [
   },
   {
     title: "Application Security",
-    slug: "appsec", 
+    slug: "application-security",
     description: "SAST, DAST, secure coding practices, vulnerability management, and application security testing.",
     level: "Intermediate",
     controls: 28,
@@ -53,15 +53,15 @@ const allTopics = [
   },
   {
     title: "Endpoint Security",
-    slug: "endpoints",
+    slug: "endpoint-security",
     description: "EDR, antivirus, device encryption, patch management, and BYOD security.",
     level: "Beginner",
     controls: 16,
     category: "Infrastructure"
   },
   {
-    title: "Container Security", 
-    slug: "containers",
+    title: "Container Security",
+    slug: "container-security",
     description: "Docker, Kubernetes security, image scanning, runtime protection, and container hardening.",
     level: "Advanced",
     controls: 38,
@@ -77,7 +77,7 @@ const allTopics = [
   },
   {
     title: "Risk Management",
-    slug: "risk-management",
+    slug: "governance-risk-compliance",
     description: "Risk assessment, business impact analysis, third-party risk, and security metrics.",
     level: "Intermediate",
     controls: 18,
@@ -85,7 +85,7 @@ const allTopics = [
   },
   {
     title: "Compliance & Governance",
-    slug: "compliance",
+    slug: "compliance-audit",
     description: "SOC 2, ISO 27001, NIST frameworks, audit preparation, and regulatory compliance.",
     level: "Advanced",
     controls: 42,

--- a/iron-codex-w3-w3schools-next/components/HomeLanding.tsx
+++ b/iron-codex-w3-w3schools-next/components/HomeLanding.tsx
@@ -11,11 +11,11 @@ import Link from "next/link";
 
 const quickLinks: { label: string; href: string; k: string }[] = [
   { label: "Security Fundamentals", href: "/topics/security-fundamentals", k: "fundamentals" },
-  { label: "AppSec", href: "/topics/appsec", k: "appsec" },
+  { label: "AppSec", href: "/topics/application-security", k: "appsec" },
   { label: "API Security", href: "/guides/api-security", k: "api" },
   { label: "Cloud Security", href: "/topics/cloud-security", k: "cloud" },
   { label: "Network Security", href: "/topics/network-security", k: "network" },
-  { label: "Identity & Access", href: "/topics/identity-access", k: "iam" },
+  { label: "Identity & Access", href: "/topics/identity-access-management", k: "iam" },
 ];
 
 const topicBuckets: { title: string; items: { label: string; href: string }[] }[] = [
@@ -23,9 +23,9 @@ const topicBuckets: { title: string; items: { label: string; href: string }[] }[
     title: "Fundamentals",
     items: [
       { label: "Security Fundamentals", href: "/topics/security-fundamentals" },
-      { label: "Identity & Access", href: "/topics/identity-access" },
+      { label: "Identity & Access", href: "/topics/identity-access-management" },
       { label: "Cryptography", href: "/topics/cryptography" },
-      { label: "Risk Management", href: "/topics/risk-management" },
+      { label: "Risk Management", href: "/topics/governance-risk-compliance" },
     ],
   },
   {
@@ -33,17 +33,17 @@ const topicBuckets: { title: string; items: { label: string; href: string }[] }[
     items: [
       { label: "Network Security", href: "/topics/network-security" },
       { label: "Cloud Security", href: "/topics/cloud-security" },
-      { label: "Endpoint Security", href: "/topics/endpoints" },
-      { label: "Supply Chain", href: "/topics/supply-chain" },
+      { label: "Endpoint Security", href: "/topics/endpoint-security" },
+      { label: "Supply Chain", href: "/topics/supply-chain-security" },
     ],
   },
   {
     title: "AppSec",
     items: [
-      { label: "Application Security", href: "/topics/appsec" },
+      { label: "Application Security", href: "/topics/application-security" },
       { label: "API Security", href: "/topics/api-security" },
       { label: "Threat Modeling", href: "/topics/threat-modeling" },
-      { label: "Vulnerability Mgmt", href: "/topics/vuln-management" },
+      { label: "Vulnerability Mgmt", href: "/topics/vulnerability-management" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- update Home landing quick links and topic buckets to use canonical topic slugs
- align the topics index data with the real directory slugs to avoid App Router 404s

## Testing
- npm run lint *(fails: existing react/no-unescaped-entities violations)*
- curl -L http://127.0.0.1:3000/topics/<slug> *(verified canonical topic routes return HTTP 200)*

------
https://chatgpt.com/codex/tasks/task_e_68ceec19e4f48322925967d78fd3a5ab