### PR TITLE
Add in-app tool detail pages

### DIFF
--- a/iron-codex-w3-w3schools-next/.eslintrc.json
+++ b/iron-codex-w3-w3schools-next/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/iron-codex-w3-w3schools-next/app/tools/[slug]/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/tools/[slug]/page.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+import { getToolBySlug, tools } from "@/data/tools";
+
+type ToolPageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+export function generateStaticParams() {
+  return tools.map((tool) => ({ slug: tool.slug }));
+}
+
+export function generateMetadata({ params }: ToolPageProps): Metadata {
+  const tool = getToolBySlug(params.slug);
+
+  if (!tool) {
+    return {
+      title: "Tool not found | Iron Codex",
+    };
+  }
+
+  return {
+    title: `${tool.name} | Security Tool`,
+    description: tool.description,
+  };
+}
+
+export default function ToolDetailPage({ params }: ToolPageProps) {
+  const tool = getToolBySlug(params.slug);
+
+  if (!tool) {
+    notFound();
+  }
+
+  const relatedTools = tools
+    .filter((candidate) => candidate.category === tool.category && candidate.slug !== tool.slug)
+    .slice(0, 3);
+
+  return (
+    <main id="main" className="min-h-screen bg-slate-950 text-slate-100">
+      <section className="border-b border-slate-800 bg-gradient-to-b from-slate-900 to-slate-950">
+        <div className="mx-auto max-w-6xl px-4 py-12 md:py-16">
+          <Link
+            href="/tools"
+            className="inline-flex items-center text-sm text-emerald-400 hover:text-emerald-300 transition"
+          >
+            <span aria-hidden>←</span>
+            <span className="ml-2">Back to tools</span>
+          </Link>
+
+          <div className="mt-6 max-w-3xl">
+            <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
+              <span className="rounded-full border border-emerald-700/60 bg-emerald-600/10 px-3 py-1">
+                {tool.category}
+              </span>
+              <span
+                className={`rounded-full px-3 py-1 font-medium ${
+                  tool.type === "Open Source"
+                    ? "bg-green-900/60 text-green-200"
+                    : tool.type === "Commercial"
+                      ? "bg-blue-900/60 text-blue-200"
+                      : tool.type === "Freemium"
+                        ? "bg-yellow-900/60 text-yellow-200"
+                        : "bg-purple-900/60 text-purple-200"
+                }`}
+              >
+                {tool.type}
+              </span>
+              <span className="rounded-full border border-slate-800 bg-slate-900/60 px-3 py-1">{tool.platform}</span>
+            </div>
+
+            <h1 className="mt-6 text-3xl font-bold tracking-tight md:text-4xl">{tool.name}</h1>
+            <p className="mt-3 text-lg text-slate-300">{tool.description}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-12 md:py-16">
+        <div className="grid gap-10 lg:grid-cols-[2fr,1fr]">
+          <article className="space-y-8">
+            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-6">
+              <h2 className="text-xl font-semibold text-emerald-400">Overview</h2>
+              <p className="mt-4 text-slate-300">
+                {tool.description} This {tool.type.toLowerCase()} tool supports {tool.category} workflows and is available on {tool.platform} deployments, making it easy to incorporate into existing security operations.
+              </p>
+            </div>
+
+            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-6">
+              <h2 className="text-xl font-semibold text-emerald-400">Key details</h2>
+              <dl className="mt-4 space-y-3 text-sm text-slate-300">
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                  <dt className="font-medium text-slate-200">Category</dt>
+                  <dd>{tool.category}</dd>
+                </div>
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                  <dt className="font-medium text-slate-200">Tool type</dt>
+                  <dd>{tool.type}</dd>
+                </div>
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                  <dt className="font-medium text-slate-200">Supported platforms</dt>
+                  <dd>{tool.platform}</dd>
+                </div>
+              </dl>
+            </div>
+          </article>
+
+          <aside className="space-y-6">
+            <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-6">
+              <h2 className="text-lg font-semibold text-emerald-400">Related tools</h2>
+              <div className="mt-4 space-y-3">
+                {relatedTools.length > 0 ? (
+                  relatedTools.map((relatedTool) => (
+                    <Link
+                      key={relatedTool.slug}
+                      href={`/tools/${relatedTool.slug}`}
+                      className="group block rounded-lg border border-slate-800 bg-slate-900/80 px-4 py-3 hover:border-slate-700 hover:bg-slate-800/70 transition"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-slate-200 group-hover:text-emerald-400">
+                          {relatedTool.name}
+                        </span>
+                        <span className="text-sm text-slate-400">{relatedTool.platform}</span>
+                      </div>
+                      <p className="mt-1 text-xs text-slate-400">{relatedTool.description}</p>
+                    </Link>
+                  ))
+                ) : (
+                  <p className="text-sm text-slate-400">More tools in this category are coming soon.</p>
+                )}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/iron-codex-w3-w3schools-next/app/tools/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/tools/page.tsx
@@ -2,73 +2,25 @@
 import React from "react";
 import Link from "next/link";
 
-const allTools = [
-  // Vulnerability Assessment
-  { name: "Nmap", slug: "nmap", category: "Vulnerability Assessment", description: "Network discovery and security auditing", type: "Open Source", platform: "Cross-platform" },
-  { name: "OpenVAS", slug: "openvas", category: "Vulnerability Assessment", description: "Comprehensive vulnerability scanner", type: "Open Source", platform: "Linux" },
-  { name: "Nuclei", slug: "nuclei", category: "Vulnerability Assessment", description: "Fast and customizable vulnerability scanner", type: "Open Source", platform: "Cross-platform" },
-  { name: "Nessus", slug: "nessus", category: "Vulnerability Assessment", description: "Professional vulnerability assessment", type: "Commercial", platform: "Cross-platform" },
-  
-  // Web Application Security
-  { name: "OWASP ZAP", slug: "owasp-zap", category: "Web Application Security", description: "Web application security scanner", type: "Open Source", platform: "Cross-platform" },
-  { name: "Burp Suite", slug: "burp-suite", category: "Web Application Security", description: "Web vulnerability scanner and proxy", type: "Freemium", platform: "Cross-platform" },
-  { name: "Nikto", slug: "nikto", category: "Web Application Security", description: "Web server scanner", type: "Open Source", platform: "Cross-platform" },
-  { name: "SQLmap", slug: "sqlmap", category: "Web Application Security", description: "Automatic SQL injection testing tool", type: "Open Source", platform: "Cross-platform" },
-  
-  // Network Security
-  { name: "Wireshark", slug: "wireshark", category: "Network Security", description: "Network protocol analyzer", type: "Open Source", platform: "Cross-platform" },
-  { name: "Snort", slug: "snort", category: "Network Security", description: "Network intrusion detection system", type: "Open Source", platform: "Cross-platform" },
-  { name: "Suricata", slug: "suricata", category: "Network Security", description: "High performance network IDS/IPS", type: "Open Source", platform: "Linux" },
-  { name: "pfSense", slug: "pfsense", category: "Network Security", description: "Open source firewall and router", type: "Open Source", platform: "FreeBSD" },
-  
-  // Digital Forensics
-  { name: "Autopsy", slug: "autopsy", category: "Digital Forensics", description: "Digital forensics platform", type: "Open Source", platform: "Cross-platform" },
-  { name: "Volatility", slug: "volatility", category: "Digital Forensics", description: "Memory forensics framework", type: "Open Source", platform: "Cross-platform" },
-  { name: "YARA", slug: "yara", category: "Digital Forensics", description: "Malware identification and classification", type: "Open Source", platform: "Cross-platform" },
-  { name: "Sleuth Kit", slug: "sleuth-kit", category: "Digital Forensics", description: "Disk image analysis tools", type: "Open Source", platform: "Cross-platform" },
-  
-  // Cloud Security
-  { name: "Scout Suite", slug: "scout-suite", category: "Cloud Security", description: "Multi-cloud security auditing tool", type: "Open Source", platform: "Cross-platform" },
-  { name: "Prowler", slug: "prowler", category: "Cloud Security", description: "AWS security best practices assessment", type: "Open Source", platform: "Cross-platform" },
-  { name: "CloudMapper", slug: "cloudmapper", category: "Cloud Security", description: "AWS environment analysis", type: "Open Source", platform: "Cross-platform" },
-  { name: "Pacu", slug: "pacu", category: "Cloud Security", description: "AWS exploitation framework", type: "Open Source", platform: "Cross-platform" },
-  
-  // Container Security
-  { name: "Trivy", slug: "trivy", category: "Container Security", description: "Vulnerability scanner for containers", type: "Open Source", platform: "Cross-platform" },
-  { name: "Falco", slug: "falco", category: "Container Security", description: "Runtime security monitoring", type: "Open Source", platform: "Linux" },
-  { name: "Clair", slug: "clair", category: "Container Security", description: "Static analysis of container vulnerabilities", type: "Open Source", platform: "Cross-platform" },
-  { name: "Docker Bench", slug: "docker-bench", category: "Container Security", description: "Docker security configuration checker", type: "Open Source", platform: "Linux" },
-  
-  // SIEM & Monitoring
-  { name: "ELK Stack", slug: "elk-stack", category: "SIEM & Monitoring", description: "Elasticsearch, Logstash, and Kibana", type: "Open Source", platform: "Cross-platform" },
-  { name: "Wazuh", slug: "wazuh", category: "SIEM & Monitoring", description: "Security monitoring platform", type: "Open Source", platform: "Cross-platform" },
-  { name: "OSSEC", slug: "ossec", category: "SIEM & Monitoring", description: "Host-based intrusion detection", type: "Open Source", platform: "Cross-platform" },
-  { name: "Graylog", slug: "graylog", category: "SIEM & Monitoring", description: "Log management and analysis", type: "Open Source", platform: "Cross-platform" },
-  
-  // Cryptography & PKI
-  { name: "OpenSSL", slug: "openssl", category: "Cryptography & PKI", description: "Cryptography and SSL/TLS toolkit", type: "Open Source", platform: "Cross-platform" },
-  { name: "HashiCorp Vault", slug: "vault", category: "Cryptography & PKI", description: "Secrets management platform", type: "Open Source", platform: "Cross-platform" },
-  { name: "Let's Encrypt", slug: "lets-encrypt", category: "Cryptography & PKI", description: "Free SSL/TLS certificates", type: "Free Service", platform: "Web-based" },
-  { name: "GnuPG", slug: "gnupg", category: "Cryptography & PKI", description: "GNU Privacy Guard", type: "Open Source", platform: "Cross-platform" }
-];
+import { toolCategories, tools, toolTypes } from "@/data/tools";
 
-const categories = ["All", "Vulnerability Assessment", "Web Application Security", "Network Security", "Digital Forensics", "Cloud Security", "Container Security", "SIEM & Monitoring", "Cryptography & PKI"];
-const types = ["All", "Open Source", "Commercial", "Freemium", "Free Service"];
+const categories = ["All", ...toolCategories];
+const types = ["All", ...toolTypes];
 
 export default function ToolsPage() {
   const [selectedCategory, setSelectedCategory] = React.useState("All");
   const [selectedType, setSelectedType] = React.useState("All");
   
-  const filteredTools = allTools.filter(tool => {
+  const filteredTools = tools.filter(tool => {
     const categoryMatch = selectedCategory === "All" || tool.category === selectedCategory;
     const typeMatch = selectedType === "All" || tool.type === selectedType;
     return categoryMatch && typeMatch;
   });
 
-  const toolsByCategory = categories.slice(1).map(category => ({
+  const toolsByCategory = toolCategories.map(category => ({
     name: category,
-    tools: allTools.filter(tool => tool.category === category),
-    count: allTools.filter(tool => tool.category === category).length
+    tools: tools.filter(tool => tool.category === category),
+    count: tools.filter(tool => tool.category === category).length
   }));
 
   return (
@@ -149,15 +101,15 @@ export default function ToolsPage() {
         {/* Stats */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
           <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-center">
-            <div className="text-2xl font-bold text-emerald-400">{allTools.length}</div>
+            <div className="text-2xl font-bold text-emerald-400">{tools.length}</div>
             <div className="text-sm text-slate-400">Total Tools</div>
           </div>
           <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-center">
-            <div className="text-2xl font-bold text-emerald-400">{categories.length - 1}</div>
+            <div className="text-2xl font-bold text-emerald-400">{toolCategories.length}</div>
             <div className="text-sm text-slate-400">Categories</div>
           </div>
           <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-center">
-            <div className="text-2xl font-bold text-emerald-400">{allTools.filter(tool => tool.type === "Open Source").length}</div>
+            <div className="text-2xl font-bold text-emerald-400">{tools.filter(tool => tool.type === "Open Source").length}</div>
             <div className="text-sm text-slate-400">Open Source</div>
           </div>
           <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 text-center">

--- a/iron-codex-w3-w3schools-next/data/tools.ts
+++ b/iron-codex-w3-w3schools-next/data/tools.ts
@@ -1,0 +1,77 @@
+export const toolCategories = [
+  "Vulnerability Assessment",
+  "Web Application Security",
+  "Network Security",
+  "Digital Forensics",
+  "Cloud Security",
+  "Container Security",
+  "SIEM & Monitoring",
+  "Cryptography & PKI",
+] as const;
+
+export const toolTypes = [
+  "Open Source",
+  "Commercial",
+  "Freemium",
+  "Free Service",
+] as const;
+
+export type ToolCategory = (typeof toolCategories)[number];
+export type ToolType = (typeof toolTypes)[number];
+
+export type Tool = {
+  name: string;
+  slug: string;
+  category: ToolCategory;
+  description: string;
+  type: ToolType;
+  platform: string;
+};
+
+export const tools: Tool[] = [
+  { name: "Nmap", slug: "nmap", category: "Vulnerability Assessment", description: "Network discovery and security auditing", type: "Open Source", platform: "Cross-platform" },
+  { name: "OpenVAS", slug: "openvas", category: "Vulnerability Assessment", description: "Comprehensive vulnerability scanner", type: "Open Source", platform: "Linux" },
+  { name: "Nuclei", slug: "nuclei", category: "Vulnerability Assessment", description: "Fast and customizable vulnerability scanner", type: "Open Source", platform: "Cross-platform" },
+  { name: "Nessus", slug: "nessus", category: "Vulnerability Assessment", description: "Professional vulnerability assessment", type: "Commercial", platform: "Cross-platform" },
+
+  { name: "OWASP ZAP", slug: "owasp-zap", category: "Web Application Security", description: "Web application security scanner", type: "Open Source", platform: "Cross-platform" },
+  { name: "Burp Suite", slug: "burp-suite", category: "Web Application Security", description: "Web vulnerability scanner and proxy", type: "Freemium", platform: "Cross-platform" },
+  { name: "Nikto", slug: "nikto", category: "Web Application Security", description: "Web server scanner", type: "Open Source", platform: "Cross-platform" },
+  { name: "SQLmap", slug: "sqlmap", category: "Web Application Security", description: "Automatic SQL injection testing tool", type: "Open Source", platform: "Cross-platform" },
+
+  { name: "Wireshark", slug: "wireshark", category: "Network Security", description: "Network protocol analyzer", type: "Open Source", platform: "Cross-platform" },
+  { name: "Snort", slug: "snort", category: "Network Security", description: "Network intrusion detection system", type: "Open Source", platform: "Cross-platform" },
+  { name: "Suricata", slug: "suricata", category: "Network Security", description: "High performance network IDS/IPS", type: "Open Source", platform: "Linux" },
+  { name: "pfSense", slug: "pfsense", category: "Network Security", description: "Open source firewall and router", type: "Open Source", platform: "FreeBSD" },
+
+  { name: "Autopsy", slug: "autopsy", category: "Digital Forensics", description: "Digital forensics platform", type: "Open Source", platform: "Cross-platform" },
+  { name: "Volatility", slug: "volatility", category: "Digital Forensics", description: "Memory forensics framework", type: "Open Source", platform: "Cross-platform" },
+  { name: "YARA", slug: "yara", category: "Digital Forensics", description: "Malware identification and classification", type: "Open Source", platform: "Cross-platform" },
+  { name: "Sleuth Kit", slug: "sleuth-kit", category: "Digital Forensics", description: "Disk image analysis tools", type: "Open Source", platform: "Cross-platform" },
+
+  { name: "Scout Suite", slug: "scout-suite", category: "Cloud Security", description: "Multi-cloud security auditing tool", type: "Open Source", platform: "Cross-platform" },
+  { name: "Prowler", slug: "prowler", category: "Cloud Security", description: "AWS security best practices assessment", type: "Open Source", platform: "Cross-platform" },
+  { name: "CloudMapper", slug: "cloudmapper", category: "Cloud Security", description: "AWS environment analysis", type: "Open Source", platform: "Cross-platform" },
+  { name: "Pacu", slug: "pacu", category: "Cloud Security", description: "AWS exploitation framework", type: "Open Source", platform: "Cross-platform" },
+
+  { name: "Trivy", slug: "trivy", category: "Container Security", description: "Vulnerability scanner for containers", type: "Open Source", platform: "Cross-platform" },
+  { name: "Falco", slug: "falco", category: "Container Security", description: "Runtime security monitoring", type: "Open Source", platform: "Linux" },
+  { name: "Clair", slug: "clair", category: "Container Security", description: "Static analysis of container vulnerabilities", type: "Open Source", platform: "Cross-platform" },
+  { name: "Docker Bench", slug: "docker-bench", category: "Container Security", description: "Docker security configuration checker", type: "Open Source", platform: "Linux" },
+
+  { name: "ELK Stack", slug: "elk-stack", category: "SIEM & Monitoring", description: "Elasticsearch, Logstash, and Kibana", type: "Open Source", platform: "Cross-platform" },
+  { name: "Wazuh", slug: "wazuh", category: "SIEM & Monitoring", description: "Security monitoring platform", type: "Open Source", platform: "Cross-platform" },
+  { name: "OSSEC", slug: "ossec", category: "SIEM & Monitoring", description: "Host-based intrusion detection", type: "Open Source", platform: "Cross-platform" },
+  { name: "Graylog", slug: "graylog", category: "SIEM & Monitoring", description: "Log management and analysis", type: "Open Source", platform: "Cross-platform" },
+
+  { name: "OpenSSL", slug: "openssl", category: "Cryptography & PKI", description: "Cryptography and SSL/TLS toolkit", type: "Open Source", platform: "Cross-platform" },
+  { name: "HashiCorp Vault", slug: "vault", category: "Cryptography & PKI", description: "Secrets management platform", type: "Open Source", platform: "Cross-platform" },
+  { name: "Let's Encrypt", slug: "lets-encrypt", category: "Cryptography & PKI", description: "Free SSL/TLS certificates", type: "Free Service", platform: "Web-based" },
+  { name: "GnuPG", slug: "gnupg", category: "Cryptography & PKI", description: "GNU Privacy Guard", type: "Open Source", platform: "Cross-platform" },
+];
+
+export const toolRecord = Object.fromEntries(tools.map((tool) => [tool.slug, tool]));
+
+export function getToolBySlug(slug: string) {
+  return toolRecord[slug];
+}

--- a/iron-codex-w3-w3schools-next/next-env.d.ts
+++ b/iron-codex-w3-w3schools-next/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/iron-codex-w3-w3schools-next/tsconfig.json
+++ b/iron-codex-w3-w3schools-next/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -14,8 +18,25 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": ".",
-    "paths": { "@/*": ["./*"] }
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- centralize the security tool metadata in a shared data module
- update the tools listing page to consume the shared dataset and keep links within the app
- add a dynamic /tools/[slug] route that renders detailed content for each tool and suggests related entries

## Testing
- `npm run lint` *(fails: existing react/no-unescaped-entities warnings in unrelated pages)*

------
https://chatgpt.com/codex/tasks/task_e_68cef01744588322be5c071a7ac79875