### PR TITLE
Remove redundant navbar from topic page

### DIFF
--- a/iron-codex-w3-w3schools-next/app/topics/[slug]/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import NavBar from "@/components/IronHeader"; // Changed from NavBar to IronHeader
 import Footer from "@/components/Footer";
 import fs from "fs";
 import path from "path";
@@ -21,7 +20,6 @@ export default function TopicPage({ params }: { params: { slug: string } }) {
 
   return (
     <>
-      <NavBar />
       <main className="container py-12" id="main">
         <div className="max-w-4xl mx-auto prose">
           <div dangerouslySetInnerHTML={{ __html: contentHtml }} />


### PR DESCRIPTION
## Summary
- remove the topic page's local navbar so it uses the layout header

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68cf04772b2483228de01767ed1a5cc4