### PR TITLE
Fix lint errors by escaping apostrophes and quotes

### DIFF
--- a/iron-codex-w3-w3schools-next/app/about/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/about/page.tsx
@@ -9,7 +9,7 @@ const teamValues = [
   },
   {
     title: "No Fluff",
-    description: "We focus on implementation details and skip the theoretical background that doesn't help practitioners."
+    description: "We focus on implementation details and skip the theoretical background that doesn&rsquo;t help practitioners."
   },
   {
     title: "Community Driven", 
@@ -57,7 +57,7 @@ export default function AboutPage() {
             </p>
             <p className="text-slate-300 text-lg leading-relaxed">
               Too many cybersecurity resources focus on high-level concepts without providing the practical 
-              implementation details needed to actually secure systems. We're changing that by creating 
+              implementation details needed to actually secure systems. We&rsquo;re changing that by creating
               comprehensive, step-by-step guidance that works in the real world.
             </p>
           </div>

--- a/iron-codex-w3-w3schools-next/app/examples/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/examples/page.tsx
@@ -24,7 +24,7 @@ export default function ExamplesPage() {
           <div className="text-6xl mb-4">🚧</div>
           <h2 className="text-2xl font-bold mb-4">Coming Soon</h2>
           <p className="text-slate-400 mb-8 max-w-2xl mx-auto">
-            We're building a comprehensive collection of practical security implementation examples. 
+            We&rsquo;re building a comprehensive collection of practical security implementation examples.
             This section will include code samples, configuration files, and step-by-step walkthroughs.
           </p>
           

--- a/iron-codex-w3-w3schools-next/app/guides/containers/[slug]/containers_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/containers/[slug]/containers_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/guides/iam/[slug]/iam_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/iam/[slug]/iam_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/guides/incident-response/[slug]/incident_response_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/incident-response/[slug]/incident_response_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/guides/saas-security/[slug]/saas_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/saas-security/[slug]/saas_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/maps/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/maps/page.tsx
@@ -24,7 +24,7 @@ export default function MapsPage() {
           <div className="text-6xl mb-4">🗺️</div>
           <h2 className="text-2xl font-bold mb-4">Coming Soon</h2>
           <p className="text-slate-400 mb-8 max-w-2xl mx-auto">
-            We're creating interactive learning maps that will guide you through cybersecurity topics 
+            We&rsquo;re creating interactive learning maps that will guide you through cybersecurity topics
             based on your experience level and career goals.
           </p>
           

--- a/iron-codex-w3-w3schools-next/app/not-found.tsx
+++ b/iron-codex-w3-w3schools-next/app/not-found.tsx
@@ -2,7 +2,7 @@ export default function NotFound(){
   return (
     <main className="container py-24 text-center">
       <h1 className="text-4xl font-extrabold mb-2">404</h1>
-      <p className="text-gray-600 mb-6">We couldn't find that page.</p>
+      <p className="text-gray-600 mb-6">We couldn&rsquo;t find that page.</p>
       <a className="btn btn-primary" href="/">Back to Home</a>
     </main>
   )

--- a/iron-codex-w3-w3schools-next/app/search/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/search/page.tsx
@@ -79,7 +79,7 @@ function SearchContent() {
             </h1>
             {query && (
               <p className="mt-3 text-slate-300 text-lg">
-                Showing results for "{query}"
+                Showing results for &ldquo;{query}&rdquo;
               </p>
             )}
             
@@ -132,7 +132,7 @@ function SearchContent() {
           <div className="text-center py-12">
             <h2 className="text-xl font-semibold mb-4">No results found</h2>
             <p className="text-slate-400 mb-8">
-              We couldn't find anything matching "{query}". Try adjusting your search terms.
+              We couldn&rsquo;t find anything matching &ldquo;{query}&rdquo;. Try adjusting your search terms.
             </p>
             
             {/* Search suggestions */}
@@ -159,7 +159,7 @@ function SearchContent() {
                 {results.length} result{results.length !== 1 ? 's' : ''} found
               </h2>
               <div className="text-sm text-slate-400">
-                Showing results for "{query}"
+                Showing results for &ldquo;{query}&rdquo;
               </div>
             </div>
 

--- a/iron-codex-w3-w3schools-next/app/topics/ai-ml-security/[slug]/ai_ml_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/ai-ml-security/[slug]/ai_ml_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/api-security/[slug]/api_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/api-security/[slug]/api_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/application-security/[slug]/application_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/application-security/[slug]/application_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/blockchain-security/[slug]/blockchain_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/blockchain-security/[slug]/blockchain_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/business-continuity/[slug]/business_continuity_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/business-continuity/[slug]/business_continuity_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/cloud-security/[slug]/cloud_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/cloud-security/[slug]/cloud_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/container-security/[slug]/container_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/container-security/[slug]/container_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/cryptography/[slug]/cryptography_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/cryptography/[slug]/cryptography_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/data-protection/[slug]/data_protection_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/data-protection/[slug]/data_protection_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/data-security/[slug]/data_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/data-security/[slug]/data_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/database-security/[slug]/database_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/database-security/[slug]/database_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/devsecops/[slug]/devsecops_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/devsecops/[slug]/devsecops_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/email-security/[slug]/email_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/email-security/[slug]/email_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/endpoint-security/[slug]/endpoint_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/endpoint-security/[slug]/endpoint_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/governance-risk-compliance/[slug]/governance_risk_compliance_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/governance-risk-compliance/[slug]/governance_risk_compliance_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/iam/[slug]/iam_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/iam/[slug]/iam_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/identity-access-management/[slug]/IAMClient.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/identity-access-management/[slug]/IAMClient.tsx
@@ -338,7 +338,7 @@ export default function IAMClient({ slug }: { slug: string }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/incident-response/[slug]/incident_response_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/incident-response/[slug]/incident_response_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/iot-security/[slug]/iot_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/iot-security/[slug]/iot_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/logging-and-monitoring/[slug]/logging_and_monitoring_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/logging-and-monitoring/[slug]/logging_and_monitoring_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/mobile-security/[slug]/mobile_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/mobile-security/[slug]/mobile_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/network-security/[slug]/network_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/network-security/[slug]/network_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/physical-security/[slug]/physical_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/physical-security/[slug]/physical_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/secrets-management/[slug]/secrets_management_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/secrets-management/[slug]/secrets_management_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/security-fundamentals/[slug]/security_fundamentals_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/security-fundamentals/[slug]/security_fundamentals_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/security-operations/[slug]/security_operations_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/security-operations/[slug]/security_operations_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/supply-chain-security/[slug]/supply_chain_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/supply-chain-security/[slug]/supply_chain_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/threat-intelligence/[slug]/threat_intelligence_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/threat-intelligence/[slug]/threat_intelligence_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/threat-modeling/[slug]/threat_modeling_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/threat-modeling/[slug]/threat_modeling_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/vulnerability-management/[slug]/vulnerability_management_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/vulnerability-management/[slug]/vulnerability_management_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/web-application-security/[slug]/web_application_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/web-application-security/[slug]/web_application_security_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/app/topics/zero-trust/[slug]/zero_trust_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/zero-trust/[slug]/zero_trust_client.tsx
@@ -344,7 +344,7 @@ export default function Client({ slug }: { slug: Slug }) {
       case "federation":
         return (
           <Card title="Identity Federation">
-            <p>Trust external IdPs ("Login with…") and map claims to local roles with least privilege.</p>
+            <p>Trust external IdPs (&ldquo;Login with…&rdquo;) and map claims to local roles with least privilege.</p>
           </Card>
         );
 

--- a/iron-codex-w3-w3schools-next/components/Footer.tsx
+++ b/iron-codex-w3-w3schools-next/components/Footer.tsx
@@ -41,7 +41,7 @@ export default function Footer(){
         </div>
       </div>
       <div className="container border-t border-gray-700 mt-6 pt-4 text-center text-gray-400 text-sm">
-        © 2024 Iron Codex. The world's largest cybersecurity reference platform.
+        © 2024 Iron Codex. The world&rsquo;s largest cybersecurity reference platform.
       </div>
     </footer>
   )

--- a/iron-codex-w3-w3schools-next/components/Hero.tsx
+++ b/iron-codex-w3-w3schools-next/components/Hero.tsx
@@ -3,7 +3,7 @@ export default function Hero(){
     <section className="bg-w3dark-hero text-white text-center py-16 md:py-24">
       <div className="container">
         <h1 className="text-4xl md:text-6xl font-extrabold mb-4">Learn Cybersecurity</h1>
-        <p className="text-w3yellow text-lg md:text-xl font-semibold mb-6">With the world's largest cybersecurity reference site.</p>
+        <p className="text-w3yellow text-lg md:text-xl font-semibold mb-6">With the world&rsquo;s largest cybersecurity reference site.</p>
 
         {/* Big W3-style search pill */}
         <form action="/search" className="mx-auto max-w-3xl">


### PR DESCRIPTION
## Summary
- escape apostrophes in hero, footer, marketing pages, and search copy to satisfy react/no-unescaped-entities
- replace inline double quotes around "Login with…" references across guide/topic client pages with HTML entities
- adjust search result messaging to use HTML entities for both apostrophes and quotes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d033d63eb88322829c7b83275957d2