### PR TITLE
Replace body navigation with promotional flares

### DIFF
--- a/iron-codex-w3-w3schools-next/app/about/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/about/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import React from "react";
-import Link from "next/link";
 
 const teamValues = [
   {

--- a/iron-codex-w3-w3schools-next/app/guides/api-security/[slug]/api_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/api-security/[slug]/api_security_client.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import dynamic from "next/dynamic";
 import { useMemo, useState } from "react";
 
@@ -52,13 +52,7 @@ export default function Client({ slug }: { slug: string }) {
                 <div className="text-xs uppercase tracking-wide text-slate-400 px-3 pt-2">{group}</div>
                 <div className="p-2 space-y-1">
                   {items.map((item) => (
-                    <Link
-                      key={item.id}
-                      href={`/guides/api-security/$${item.id}`}
-                      className={`block px-3 py-1.5 rounded-md border transition-colors ${slug === item.id ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-300" : "border-transparent hover:border-slate-700 text-slate-300 hover:text-slate-200"}`}
-                    >
-                      {item.label}
-                    </Link>
+                    <PromoFlare key={item.id} label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                   ))}
                 </div>
               </div>

--- a/iron-codex-w3-w3schools-next/app/guides/cloud-security/[slug]/cloud_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/cloud-security/[slug]/cloud_security_client.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import dynamic from "next/dynamic";
 import { useMemo, useState } from "react";
 
@@ -52,13 +52,7 @@ export default function Client({ slug }: { slug: string }) {
                 <div className="text-xs uppercase tracking-wide text-slate-400 px-3 pt-2">{group}</div>
                 <div className="p-2 space-y-1">
                   {items.map((item) => (
-                    <Link
-                      key={item.id}
-                      href={`/guides/cloud-security/$${item.id}`}
-                      className={`block px-3 py-1.5 rounded-md border transition-colors ${slug === item.id ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-300" : "border-transparent hover:border-slate-700 text-slate-300 hover:text-slate-200"}`}
-                    >
-                      {item.label}
-                    </Link>
+                    <PromoFlare key={item.id} label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                   ))}
                 </div>
               </div>

--- a/iron-codex-w3-w3schools-next/app/guides/containers/[slug]/containers_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/containers/[slug]/containers_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/guides/iam/[slug]/iam_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/iam/[slug]/iam_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/guides/incident-response/[slug]/incident_response_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/incident-response/[slug]/incident_response_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/guides/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from "react";
-import Link from "next/link";
+import { PromoBadge } from "@/components/PromoFlare";
 
 const allGuides = [
   {
@@ -158,39 +158,44 @@ export default function GuidesPage() {
         {/* Guides Grid */}
         <div className="space-y-6">
           {filteredGuides.map((guide) => (
-            <Link
+            <article
               key={guide.slug}
-              href={`/guides/${guide.slug}`}
-              className="group block rounded-xl border border-slate-800 bg-slate-900/60 p-6 hover:bg-slate-800/60 hover:border-slate-700 transition-all hover:-translate-y-1 hover:shadow-xl"
+              className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 transition-all cursor-default"
             >
               <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-2">
-                    <h2 className="text-xl font-bold group-hover:text-emerald-400 transition-colors">
+                    <h2 className="text-xl font-bold text-emerald-200">
                       {guide.title}
                     </h2>
-                    <span className={`px-2 py-1 text-xs rounded-full ${
-                      guide.level === 'Beginner' ? 'bg-green-900 text-green-200' :
-                      guide.level === 'Intermediate' ? 'bg-yellow-900 text-yellow-200' :
-                      'bg-red-900 text-red-200'
-                    }`}>
-                      {guide.level}
-                    </span>
+                    <PromoBadge
+                      label={guide.level}
+                      tone="active"
+                      className={
+                        guide.level === 'Beginner'
+                          ? 'bg-green-900/60 border-green-500/50 text-green-100'
+                          : guide.level === 'Intermediate'
+                            ? 'bg-yellow-900/60 border-yellow-500/50 text-yellow-100'
+                            : 'bg-red-900/60 border-red-500/50 text-red-100'
+                      }
+                    />
                   </div>
-                  
+
                   <p className="text-slate-300 mb-4 leading-relaxed">
                     {guide.description}
                   </p>
-                  
+
                   <div className="flex flex-wrap gap-2 mb-3">
                     {guide.topics.map((topic) => (
-                      <span key={topic} className="px-2 py-1 text-xs bg-slate-800 text-slate-300 rounded">
-                        {topic}
-                      </span>
+                      <PromoBadge
+                        key={topic}
+                        label={topic}
+                        className="bg-slate-800/80 border-slate-700/80 text-slate-200"
+                      />
                     ))}
                   </div>
                 </div>
-                
+
                 <div className="flex flex-col items-end gap-2 text-right">
                   <div className="text-sm text-emerald-400 font-medium">
                     {guide.category}
@@ -198,12 +203,10 @@ export default function GuidesPage() {
                   <div className="text-sm text-slate-400">
                     {guide.readTime} read
                   </div>
-                  <div className="text-emerald-400 group-hover:translate-x-2 transition-transform text-sm">
-                    Read guide →
-                  </div>
+                  <div className="text-emerald-400 text-sm uppercase tracking-[0.3em]">Preview</div>
                 </div>
               </div>
-            </Link>
+            </article>
           ))}
         </div>
       </section>

--- a/iron-codex-w3-w3schools-next/app/guides/saas-security/[slug]/saas_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/guides/saas-security/[slug]/saas_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/layout.tsx
+++ b/iron-codex-w3-w3schools-next/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <a href="#main" className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 bg-white border px-3 py-2 rounded">Skip to content</a>
+        <span className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 bg-white border px-3 py-2 rounded">Skip to content</span>
         <NavBar /> 
         {children}
         <Analytics />

--- a/iron-codex-w3-w3schools-next/app/not-found.tsx
+++ b/iron-codex-w3-w3schools-next/app/not-found.tsx
@@ -1,9 +1,11 @@
+import { PromoBadge } from "@/components/PromoFlare";
+
 export default function NotFound(){
   return (
     <main className="container py-24 text-center">
       <h1 className="text-4xl font-extrabold mb-2">404</h1>
       <p className="text-gray-600 mb-6">We couldn&rsquo;t find that page.</p>
-      <a className="btn btn-primary" href="/">Back to Home</a>
+      <PromoBadge label="Back to Home" tone="active" className="btn btn-primary inline-flex justify-center" />
     </main>
   )
 }

--- a/iron-codex-w3-w3schools-next/app/search/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/search/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { Suspense } from "react";
-import Link from "next/link";
+import { PromoBadge } from "@/components/PromoFlare";
 import { useSearchParams } from "next/navigation";
 
 // Mock search results - in a real app, this would come from your search API
@@ -48,12 +48,6 @@ const mockResults = [
     category: "Container Security"
   }
 ];
-
-const typeColors = {
-  "Topic": "bg-blue-900 text-blue-200",
-  "Guide": "bg-green-900 text-green-200", 
-  "Tool": "bg-purple-900 text-purple-200"
-};
 
 function SearchContent() {
   const searchParams = useSearchParams();
@@ -116,13 +110,7 @@ function SearchContent() {
               <h3 className="text-lg font-medium mb-4">Popular Searches</h3>
               <div className="flex flex-wrap gap-2 justify-center">
                 {["API Security", "Container Security", "Zero Trust", "Identity Management", "Cloud Security", "Vulnerability Scanning"].map((term) => (
-                  <Link
-                    key={term}
-                    href={`/search?q=${encodeURIComponent(term)}`}
-                    className="px-3 py-2 rounded-lg border border-slate-700 text-slate-300 hover:bg-slate-800 hover:border-slate-600 hover:text-emerald-400 transition text-sm"
-                  >
-                    {term}
-                  </Link>
+                  <PromoBadge key={term} label={term} tone="active" className="cursor-default" />
                 ))}
               </div>
             </div>
@@ -140,13 +128,7 @@ function SearchContent() {
               <h3 className="text-lg font-medium mb-4">Try searching for:</h3>
               <div className="flex flex-wrap gap-2 justify-center">
                 {["Security fundamentals", "Application security", "Network security", "Cloud security"].map((term) => (
-                  <Link
-                    key={term}
-                    href={`/search?q=${encodeURIComponent(term)}`}
-                    className="px-3 py-2 rounded-lg border border-slate-700 text-slate-300 hover:bg-slate-800 hover:border-slate-600 hover:text-emerald-400 transition text-sm"
-                  >
-                    {term}
-                  </Link>
+                  <PromoBadge key={term} label={term} tone="active" className="cursor-default" />
                 ))}
               </div>
             </div>
@@ -166,36 +148,31 @@ function SearchContent() {
             {/* Results List */}
             <div className="space-y-6">
               {results.map((result, index) => (
-                <Link
+                <article
                   key={index}
-                  href={result.url}
-                  className="group block rounded-xl border border-slate-800 bg-slate-900/60 p-6 hover:bg-slate-800/60 hover:border-slate-700 transition-all hover:-translate-y-1 hover:shadow-xl"
+                  className="group block rounded-xl border border-slate-800 bg-slate-900/60 p-6 transition-all cursor-default"
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex-1">
                       <div className="flex items-center gap-3 mb-2">
-                        <h3 className="text-lg font-semibold group-hover:text-emerald-400 transition-colors">
+                        <h3 className="text-lg font-semibold text-emerald-200">
                           {result.title}
                         </h3>
-                        <span className={`px-2 py-1 text-xs rounded ${typeColors[result.type as keyof typeof typeColors]}`}>
-                          {result.type}
-                        </span>
+                        <PromoBadge label={result.type} tone="active" />
                       </div>
-                      
+
                       <p className="text-slate-300 mb-3 leading-relaxed">
                         {result.excerpt}
                       </p>
-                      
+
                       <div className="text-sm text-slate-400">
                         {result.category}
                       </div>
                     </div>
-                    
-                    <div className="text-emerald-400 group-hover:translate-x-2 transition-transform">
-                      →
-                    </div>
+
+                    <div className="text-emerald-400 text-sm uppercase tracking-[0.3em]">Preview</div>
                   </div>
-                </Link>
+                </article>
               ))}
             </div>
           </>

--- a/iron-codex-w3-w3schools-next/app/tools/[slug]/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/tools/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { PromoBadge } from "@/components/PromoFlare";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
@@ -44,13 +44,16 @@ export default function ToolDetailPage({ params }: ToolPageProps) {
     <main id="main" className="min-h-screen bg-slate-950 text-slate-100">
       <section className="border-b border-slate-800 bg-gradient-to-b from-slate-900 to-slate-950">
         <div className="mx-auto max-w-6xl px-4 py-12 md:py-16">
-          <Link
-            href="/tools"
-            className="inline-flex items-center text-sm text-emerald-400 hover:text-emerald-300 transition"
-          >
-            <span aria-hidden>←</span>
-            <span className="ml-2">Back to tools</span>
-          </Link>
+          <PromoBadge
+            label={(
+              <span className="flex items-center gap-2">
+                <span aria-hidden>←</span>
+                <span>Back to tools</span>
+              </span>
+            )}
+            tone="active"
+            className="text-sm"
+          />
 
           <div className="mt-6 max-w-3xl">
             <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
@@ -114,19 +117,18 @@ export default function ToolDetailPage({ params }: ToolPageProps) {
               <div className="mt-4 space-y-3">
                 {relatedTools.length > 0 ? (
                   relatedTools.map((relatedTool) => (
-                    <Link
+                    <article
                       key={relatedTool.slug}
-                      href={`/tools/${relatedTool.slug}`}
-                      className="group block rounded-lg border border-slate-800 bg-slate-900/80 px-4 py-3 hover:border-slate-700 hover:bg-slate-800/70 transition"
+                      className="rounded-lg border border-slate-800 bg-slate-900/80 px-4 py-3 transition cursor-default"
                     >
                       <div className="flex items-center justify-between">
-                        <span className="font-medium text-slate-200 group-hover:text-emerald-400">
+                        <span className="font-medium text-slate-200 text-emerald-200">
                           {relatedTool.name}
                         </span>
-                        <span className="text-sm text-slate-400">{relatedTool.platform}</span>
+                        <PromoBadge label={relatedTool.platform} className="text-[10px]" />
                       </div>
                       <p className="mt-1 text-xs text-slate-400">{relatedTool.description}</p>
-                    </Link>
+                    </article>
                   ))
                 ) : (
                   <p className="text-sm text-slate-400">More tools in this category are coming soon.</p>

--- a/iron-codex-w3-w3schools-next/app/tools/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/tools/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from "react";
-import Link from "next/link";
+import { PromoBadge, PromoFlare } from "@/components/PromoFlare";
 
 import { toolCategories, tools, toolTypes } from "@/data/tools";
 
@@ -136,23 +136,27 @@ export default function ToolsPage() {
                   {category.tools
                     .filter(tool => selectedType === "All" || tool.type === selectedType)
                     .map((tool) => (
-                    <Link
+                    <article
                       key={tool.slug}
-                      href={`/tools/${tool.slug}`}
-                      className="group rounded-xl border border-slate-800 bg-slate-900/60 p-4 hover:bg-slate-800/60 hover:border-slate-700 transition-all hover:-translate-y-1 hover:shadow-lg"
+                      className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 transition-all cursor-default"
                     >
                       <div className="flex justify-between items-start mb-2">
-                        <h3 className="font-semibold group-hover:text-emerald-400 transition-colors">
+                        <h3 className="font-semibold text-emerald-200">
                           {tool.name}
                         </h3>
-                        <span className={`px-2 py-1 text-xs rounded ${
-                          tool.type === 'Open Source' ? 'bg-green-900 text-green-200' :
-                          tool.type === 'Commercial' ? 'bg-blue-900 text-blue-200' :
-                          tool.type === 'Freemium' ? 'bg-yellow-900 text-yellow-200' :
-                          'bg-purple-900 text-purple-200'
-                        }`}>
-                          {tool.type}
-                        </span>
+                        <PromoBadge
+                          label={tool.type}
+                          tone="active"
+                          className={
+                            tool.type === 'Open Source'
+                              ? 'bg-green-900/60 border-green-500/50 text-green-100'
+                              : tool.type === 'Commercial'
+                                ? 'bg-blue-900/60 border-blue-500/50 text-blue-100'
+                                : tool.type === 'Freemium'
+                                  ? 'bg-yellow-900/60 border-yellow-500/50 text-yellow-100'
+                                  : 'bg-purple-900/60 border-purple-500/50 text-purple-100'
+                          }
+                        />
                       </div>
                       <p className="text-sm text-slate-300 mb-3">
                         {tool.description}
@@ -161,11 +165,9 @@ export default function ToolsPage() {
                         <span className="text-xs text-slate-400">
                           {tool.platform}
                         </span>
-                        <span className="text-emerald-400 group-hover:translate-x-1 transition-transform text-sm">
-                          →
-                        </span>
+                        <span className="text-emerald-400 text-sm uppercase tracking-[0.3em]">Preview</span>
                       </div>
-                    </Link>
+                    </article>
                   ))}
                 </div>
               </div>
@@ -175,23 +177,27 @@ export default function ToolsPage() {
           // Show filtered results when specific category is selected
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {filteredTools.map((tool) => (
-              <Link
+              <article
                 key={tool.slug}
-                href={`/tools/${tool.slug}`}
-                className="group rounded-xl border border-slate-800 bg-slate-900/60 p-4 hover:bg-slate-800/60 hover:border-slate-700 transition-all hover:-translate-y-1 hover:shadow-lg"
+                className="rounded-xl border border-slate-800 bg-slate-900/60 p-4 transition-all cursor-default"
               >
                 <div className="flex justify-between items-start mb-2">
-                  <h3 className="font-semibold group-hover:text-emerald-400 transition-colors">
+                  <h3 className="font-semibold text-emerald-200">
                     {tool.name}
                   </h3>
-                  <span className={`px-2 py-1 text-xs rounded ${
-                    tool.type === 'Open Source' ? 'bg-green-900 text-green-200' :
-                    tool.type === 'Commercial' ? 'bg-blue-900 text-blue-200' :
-                    tool.type === 'Freemium' ? 'bg-yellow-900 text-yellow-200' :
-                    'bg-purple-900 text-purple-200'
-                  }`}>
-                    {tool.type}
-                  </span>
+                  <PromoBadge
+                    label={tool.type}
+                    tone="active"
+                    className={
+                      tool.type === 'Open Source'
+                        ? 'bg-green-900/60 border-green-500/50 text-green-100'
+                        : tool.type === 'Commercial'
+                          ? 'bg-blue-900/60 border-blue-500/50 text-blue-100'
+                          : tool.type === 'Freemium'
+                            ? 'bg-yellow-900/60 border-yellow-500/50 text-yellow-100'
+                            : 'bg-purple-900/60 border-purple-500/50 text-purple-100'
+                    }
+                  />
                 </div>
                 <p className="text-sm text-slate-300 mb-3">
                   {tool.description}
@@ -200,11 +206,9 @@ export default function ToolsPage() {
                   <span className="text-xs text-slate-400">
                     {tool.platform}
                   </span>
-                  <span className="text-emerald-400 group-hover:translate-x-1 transition-transform text-sm">
-                    →
-                  </span>
+                  <span className="text-emerald-400 text-sm uppercase tracking-[0.3em]">Preview</span>
                 </div>
-              </Link>
+              </article>
             ))}
           </div>
         )}
@@ -215,12 +219,9 @@ export default function ToolsPage() {
           <p className="text-slate-300 mb-6">
             Help us expand our collection with community recommendations.
           </p>
-          <Link
-            href="https://github.com/iron-codex"
-            className="inline-flex items-center px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white transition"
-          >
-            Submit on GitHub
-          </Link>
+          <div className="max-w-sm mx-auto">
+            <PromoFlare label="Submit on GitHub" eyebrow="Community Preview" align="center" />
+          </div>
         </section>
       </section>
 

--- a/iron-codex-w3-w3schools-next/app/topics/ai-ml-security/[slug]/ai_ml_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/ai-ml-security/[slug]/ai_ml_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/api-security/[slug]/api_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/api-security/[slug]/api_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/application-security/[slug]/application_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/application-security/[slug]/application_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/blockchain-security/[slug]/blockchain_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/blockchain-security/[slug]/blockchain_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/business-continuity/[slug]/business_continuity_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/business-continuity/[slug]/business_continuity_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/cloud-security/[slug]/cloud_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/cloud-security/[slug]/cloud_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/compliance-audit/[slug]/compliance_audit_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/compliance-audit/[slug]/compliance_audit_client.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import dynamic from "next/dynamic";
 import { useMemo, useState } from "react";
 
@@ -52,13 +52,7 @@ export default function Client({ slug }: { slug: string }) {
                 <div className="text-xs uppercase tracking-wide text-slate-400 px-3 pt-2">{group}</div>
                 <div className="p-2 space-y-1">
                   {items.map((item) => (
-                    <Link
-                      key={item.id}
-                      href={`/topics/compliance-audit/${item.id}`}
-                      className={`block px-3 py-1.5 rounded-md border transition-colors ${slug === item.id ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-300" : "border-transparent hover:border-slate-700 text-slate-300 hover:text-slate-200"}`}
-                    >
-                      {item.label}
-                    </Link>
+                    <PromoFlare key={item.id} label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                   ))}
                 </div>
               </div>

--- a/iron-codex-w3-w3schools-next/app/topics/container-security/[slug]/container_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/container-security/[slug]/container_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/cryptography/[slug]/cryptography_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/cryptography/[slug]/cryptography_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/data-protection/[slug]/data_protection_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/data-protection/[slug]/data_protection_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/data-security/[slug]/data_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/data-security/[slug]/data_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/database-security/[slug]/database_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/database-security/[slug]/database_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/devsecops/[slug]/devsecops_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/devsecops/[slug]/devsecops_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/email-security/[slug]/email_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/email-security/[slug]/email_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/endpoint-security/[slug]/endpoint_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/endpoint-security/[slug]/endpoint_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/governance-risk-compliance/[slug]/governance_risk_compliance_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/governance-risk-compliance/[slug]/governance_risk_compliance_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/iam/[slug]/iam_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/iam/[slug]/iam_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/identity-access-management/[slug]/IAMClient.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/identity-access-management/[slug]/IAMClient.tsx
@@ -1,7 +1,7 @@
 // FIXID:0cabbbd7-a8f6-4da5-81f7-7d1d612300b0
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -490,30 +490,19 @@ export default function IAMClient({ slug }: { slug: string }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
+                        <PromoFlare
                           key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                          label={c.label}
+                          tone={slug === c.id ? "active" : "default"}
+                          size="sm"
+                          eyebrow="Preview Lesson"
+                        />
                       ))}
                     </div>
                   </details>
@@ -522,8 +511,8 @@ export default function IAMClient({ slug }: { slug: string }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/incident-response/[slug]/incident_response_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/incident-response/[slug]/incident_response_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/iot-security/[slug]/iot_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/iot-security/[slug]/iot_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/logging-and-monitoring/[slug]/logging_and_monitoring_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/logging-and-monitoring/[slug]/logging_and_monitoring_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/mobile-security/[slug]/mobile_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/mobile-security/[slug]/mobile_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/network-security/[slug]/network_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/network-security/[slug]/network_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/page.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from "react";
-import Link from "next/link";
+import { PromoBadge } from "@/components/PromoFlare";
 
 const allTopics = [
   {
@@ -182,22 +182,25 @@ export default function TopicsPage() {
         {/* Topics Grid */}
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {filteredTopics.map((topic) => (
-            <Link
+            <article
               key={topic.slug}
-              href={`/topics/${topic.slug}`}
-              className="group rounded-xl border border-slate-800 bg-slate-900/60 p-6 hover:bg-slate-800/60 hover:border-slate-700 transition-all hover:-translate-y-1 hover:shadow-xl"
+              className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 transition-all cursor-default"
             >
               <div className="flex justify-between items-start mb-3">
-                <h2 className="text-xl font-bold group-hover:text-emerald-400 transition-colors">
+                <h2 className="text-xl font-bold text-emerald-200">
                   {topic.title}
                 </h2>
-                <span className={`px-2 py-1 text-xs rounded-full ${
-                  topic.level === 'Beginner' ? 'bg-green-900 text-green-200' :
-                  topic.level === 'Intermediate' ? 'bg-yellow-900 text-yellow-200' :
-                  'bg-red-900 text-red-200'
-                }`}>
-                  {topic.level}
-                </span>
+                <PromoBadge
+                  label={topic.level}
+                  tone="active"
+                  className={
+                    topic.level === 'Beginner'
+                      ? 'bg-green-900/60 border-green-500/50 text-green-100'
+                      : topic.level === 'Intermediate'
+                        ? 'bg-yellow-900/60 border-yellow-500/50 text-yellow-100'
+                        : 'bg-red-900/60 border-red-500/50 text-red-100'
+                  }
+                />
               </div>
               <p className="text-slate-300 mb-4 text-sm leading-relaxed">
                 {topic.description}
@@ -206,11 +209,9 @@ export default function TopicsPage() {
                 <span className="text-sm font-medium text-slate-400">
                   {topic.controls} controls
                 </span>
-                <span className="text-emerald-400 group-hover:translate-x-2 transition-transform text-sm">
-                  Learn more →
-                </span>
+                <span className="text-emerald-400 text-sm uppercase tracking-[0.3em]">Preview</span>
               </div>
-            </Link>
+            </article>
           ))}
         </div>
       </section>

--- a/iron-codex-w3-w3schools-next/app/topics/physical-security/[slug]/physical_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/physical-security/[slug]/physical_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/secrets-management/[slug]/secrets_management_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/secrets-management/[slug]/secrets_management_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/security-fundamentals/[slug]/security_fundamentals_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/security-fundamentals/[slug]/security_fundamentals_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/security-operations/[slug]/security_operations_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/security-operations/[slug]/security_operations_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/supply-chain-security/[slug]/supply_chain_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/supply-chain-security/[slug]/supply_chain_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/threat-intelligence/[slug]/threat_intelligence_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/threat-intelligence/[slug]/threat_intelligence_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/threat-modeling/[slug]/threat_modeling_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/threat-modeling/[slug]/threat_modeling_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/vulnerability-management/[slug]/vulnerability_management_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/vulnerability-management/[slug]/vulnerability_management_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/web-application-security/[slug]/web_application_security_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/web-application-security/[slug]/web_application_security_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/app/topics/zero-trust/[slug]/zero_trust_client.tsx
+++ b/iron-codex-w3-w3schools-next/app/topics/zero-trust/[slug]/zero_trust_client.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "@/components/PromoFlare";
 import { useRouter } from "next/navigation";
 
 /**
@@ -496,30 +496,13 @@ export default function Client({ slug }: { slug: Slug }) {
             {filteredToc.map((item, idx) => (
               <div key={idx}>
                 {"id" in item ? (
-                  <Link
-                    href={hrefFor(item.id)}
-                    className={
-                      "block px-3 py-2 rounded-lg hover:bg-slate-800 " +
-                      (slug === item.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                    }
-                  >
-                    {item.label}
-                  </Link>
+                  <PromoFlare label={item.label} tone={slug === item.id ? "active" : "default"} eyebrow="Preview Series" />
                 ) : (
                   <details open className="rounded-xl border border-slate-800 bg-slate-900/40">
                     <summary className="cursor-pointer px-3 py-2 font-semibold">{item.label}</summary>
                     <div className="px-2 pb-2 space-y-1">
                       {item.children.map((c) => (
-                        <Link
-                          key={c.id}
-                          href={hrefFor(c.id)}
-                          className={
-                            "block px-3 py-1.5 rounded-lg text-slate-300 hover:bg-slate-800 " +
-                            (slug === c.id ? "border border-emerald-400/40 bg-emerald-400/10" : "")
-                          }
-                        >
-                          {c.label}
-                        </Link>
+                        <PromoFlare key={c.id} label={c.label} tone={slug === c.id ? "active" : "default"} size="sm" eyebrow="Preview Lesson" />
                       ))}
                     </div>
                   </details>
@@ -528,8 +511,8 @@ export default function Client({ slug }: { slug: Slug }) {
             ))}
           </div>
           <h4 className="px-2 mt-4 mb-1 text-xs uppercase tracking-widest text-slate-400">Practice</h4>
-          <Link href={hrefFor("quiz")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Section Quiz</Link>
-          <Link href={hrefFor("snippets")} className="block px-3 py-2 rounded-lg hover:bg-slate-800">Snippets</Link>
+          <PromoFlare label="Section Quiz" eyebrow="Practice Preview" />
+          <PromoFlare label="Snippets" eyebrow="Practice Preview" />
         </nav>
       </aside>
 

--- a/iron-codex-w3-w3schools-next/components/Featured.tsx
+++ b/iron-codex-w3-w3schools-next/components/Featured.tsx
@@ -1,11 +1,11 @@
 export default function Featured(){
   const cards = [
-    { href: "/guides/api-security", icon:"🔐", title:"API Security Expanded", desc:"74 essential controls for securing APIs." },
-    { href: "/guides/cloud-security", icon:"☁️", title:"Cloud Security & CDN", desc:"59 controls for cloud infrastructure." },
-    { href: "/guides/saas-security", icon:"🏢", title:"SaaS Security", desc:"59 controls for SaaS platforms." },
-    { href: "/guides/iam", icon:"🔑", title:"Identity & Access Management", desc:"47 controls for IAM systems." },
-    { href: "/guides/containers", icon:"📦", title:"Containers & Kubernetes", desc:"29 controls for container security." },
-    { href: "/guides/incident-response", icon:"🚨", title:"Logging & Incident Response", desc:"25 controls for incident management." },
+    { icon:"🔐", title:"API Security Expanded", desc:"74 essential controls for securing APIs." },
+    { icon:"☁️", title:"Cloud Security & CDN", desc:"59 controls for cloud infrastructure." },
+    { icon:"🏢", title:"SaaS Security", desc:"59 controls for SaaS platforms." },
+    { icon:"🔑", title:"Identity & Access Management", desc:"47 controls for IAM systems." },
+    { icon:"📦", title:"Containers & Kubernetes", desc:"29 controls for container security." },
+    { icon:"🚨", title:"Logging & Incident Response", desc:"25 controls for incident management." },
   ];
   return (
     <section className="py-12 bg-gray-50">
@@ -13,12 +13,12 @@ export default function Featured(){
         <h2 className="text-2xl md:text-3xl text-blue-900 font-medium text-center mb-6">Featured Guides</h2>
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
           {cards.map(c => (
-            <a key={c.title} href={c.href} className="card">
+            <div key={c.title} className="card">
               <div className="text-2xl">{c.icon}</div>
               <h3 className="text-lg font-semibold">{c.title}</h3>
               <p className="text-gray-600">{c.desc}</p>
               <span className="mt-2 inline-block text-sm font-bold px-2 py-1 rounded bg-w3yellow">Deep dive guide</span>
-            </a>
+            </div>
           ))}
         </div>
       </div>

--- a/iron-codex-w3-w3schools-next/components/Footer.tsx
+++ b/iron-codex-w3-w3schools-next/components/Footer.tsx
@@ -1,44 +1,44 @@
+import { PromoFlare } from "./PromoFlare";
+
+const sections: { title: string; eyebrow: string; items: string[] }[] = [
+  {
+    title: "Security References",
+    eyebrow: "Preview Index",
+    items: ["API Security", "Cloud Security", "Container Security", "Identity & Access", "All References"],
+  },
+  {
+    title: "Implementation Guides",
+    eyebrow: "Guide Preview",
+    items: ["Getting Started", "Best Practices", "Compliance Mapping", "Tool Integration"],
+  },
+  {
+    title: "Resources",
+    eyebrow: "Ecosystem",
+    items: ["Security Tools", "Vendor Documentation", "Standards & Frameworks", "Community"],
+  },
+  {
+    title: "About",
+    eyebrow: "Team",
+    items: ["Our Mission", "Contributing", "Contact", "GitHub"],
+  },
+];
+
 export default function Footer(){
   return (
     <footer className="bg-[#111827] text-white pt-12 pb-6">
       <div className="container grid gap-6 md:grid-cols-4">
-        <div>
-          <h3 className="text-sky-400 font-semibold mb-2">Security References</h3>
-          <ul className="space-y-2 text-gray-300">
-            <li><a href="/topics/api-security">API Security</a></li>
-            <li><a href="/topics/cloud-security">Cloud Security</a></li>
-            <li><a href="/topics/container-security">Container Security</a></li>
-            <li><a href="/topics/identity-access">Identity & Access</a></li>
-            <li><a href="/topics">All References</a></li>
-          </ul>
-        </div>
-        <div>
-          <h3 className="text-sky-400 font-semibold mb-2">Implementation Guides</h3>
-          <ul className="space-y-2 text-gray-300">
-            <li><a href="/guides">Getting Started</a></li>
-            <li><a href="/guides/best-practices">Best Practices</a></li>
-            <li><a href="/maps">Compliance Mapping</a></li>
-            <li><a href="/guides/tools">Tool Integration</a></li>
-          </ul>
-        </div>
-        <div>
-          <h3 className="text-sky-400 font-semibold mb-2">Resources</h3>
-          <ul className="space-y-2 text-gray-300">
-            <li><a href="/tools">Security Tools</a></li>
-            <li><a href="/vendors">Vendor Documentation</a></li>
-            <li><a href="/standards">Standards & Frameworks</a></li>
-            <li><a href="/community">Community</a></li>
-          </ul>
-        </div>
-        <div>
-          <h3 className="text-sky-400 font-semibold mb-2">About</h3>
-          <ul className="space-y-2 text-gray-300">
-            <li><a href="/about">Our Mission</a></li>
-            <li><a href="/contributing">Contributing</a></li>
-            <li><a href="/contact">Contact</a></li>
-            <li><a href="https://github.com/cp262808">GitHub</a></li>
-          </ul>
-        </div>
+        {sections.map((section) => (
+          <div key={section.title}>
+            <h3 className="text-sky-400 font-semibold mb-2">{section.title}</h3>
+            <ul className="space-y-2 text-gray-300">
+              {section.items.map((item) => (
+                <li key={item}>
+                  <PromoFlare label={item} eyebrow={section.eyebrow} size="sm" />
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
       </div>
       <div className="container border-t border-gray-700 mt-6 pt-4 text-center text-gray-400 text-sm">
         © 2024 Iron Codex. The world&rsquo;s largest cybersecurity reference platform.

--- a/iron-codex-w3-w3schools-next/components/Hero.tsx
+++ b/iron-codex-w3-w3schools-next/components/Hero.tsx
@@ -1,3 +1,5 @@
+import { PromoBadge } from "./PromoFlare";
+
 export default function Hero(){
   return (
     <section className="bg-w3dark-hero text-white text-center py-16 md:py-24">
@@ -27,9 +29,9 @@ export default function Hero(){
           </div>
         </form>
 
-        <p className="mt-6">
-          <a href="/start" className="underline font-semibold">Not Sure Where To Begin?</a>
-        </p>
+        <div className="mt-6 flex justify-center">
+          <PromoBadge label="Not Sure Where To Begin?" tone="active" className="text-base px-5 py-2" />
+        </div>
       </div>
     </section>
   )

--- a/iron-codex-w3-w3schools-next/components/HomeLanding.tsx
+++ b/iron-codex-w3-w3schools-next/components/HomeLanding.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from "react";
-import Link from "next/link";
+import { PromoBadge, PromoFlare } from "./PromoFlare";
 
 /** Iron Codex Landing (clean, W3-style utility-first, less flashy)
  *  - Hero with primary search
@@ -9,61 +9,61 @@ import Link from "next/link";
  *  - Tools spotlight
  */
 
-const quickLinks: { label: string; href: string; k: string }[] = [
-  { label: "Security Fundamentals", href: "/topics/security-fundamentals", k: "fundamentals" },
-  { label: "AppSec", href: "/topics/application-security", k: "appsec" },
-  { label: "API Security", href: "/guides/api-security", k: "api" },
-  { label: "Cloud Security", href: "/topics/cloud-security", k: "cloud" },
-  { label: "Network Security", href: "/topics/network-security", k: "network" },
-  { label: "Identity & Access", href: "/topics/identity-access-management", k: "iam" },
+const quickLinks: { label: string; eyebrow: string; k: string }[] = [
+  { label: "Security Fundamentals", eyebrow: "Preview Track", k: "fundamentals" },
+  { label: "AppSec", eyebrow: "Preview Track", k: "appsec" },
+  { label: "API Security", eyebrow: "Guide Sneak Peek", k: "api" },
+  { label: "Cloud Security", eyebrow: "Preview Track", k: "cloud" },
+  { label: "Network Security", eyebrow: "Preview Track", k: "network" },
+  { label: "Identity & Access", eyebrow: "Preview Track", k: "iam" },
 ];
 
-const topicBuckets: { title: string; items: { label: string; href: string }[] }[] = [
+const topicBuckets: { title: string; items: { label: string; eyebrow?: string }[] }[] = [
   {
     title: "Fundamentals",
     items: [
-      { label: "Security Fundamentals", href: "/topics/security-fundamentals" },
-      { label: "Identity & Access", href: "/topics/identity-access-management" },
-      { label: "Cryptography", href: "/topics/cryptography" },
-      { label: "Risk Management", href: "/topics/governance-risk-compliance" },
+      { label: "Security Fundamentals", eyebrow: "Curriculum" },
+      { label: "Identity & Access", eyebrow: "Curriculum" },
+      { label: "Cryptography", eyebrow: "Curriculum" },
+      { label: "Risk Management", eyebrow: "Curriculum" },
     ],
   },
   {
     title: "Network & Infra",
     items: [
-      { label: "Network Security", href: "/topics/network-security" },
-      { label: "Cloud Security", href: "/topics/cloud-security" },
-      { label: "Endpoint Security", href: "/topics/endpoint-security" },
-      { label: "Supply Chain", href: "/topics/supply-chain-security" },
+      { label: "Network Security", eyebrow: "Curriculum" },
+      { label: "Cloud Security", eyebrow: "Curriculum" },
+      { label: "Endpoint Security", eyebrow: "Curriculum" },
+      { label: "Supply Chain", eyebrow: "Curriculum" },
     ],
   },
   {
     title: "AppSec",
     items: [
-      { label: "Application Security", href: "/topics/application-security" },
-      { label: "API Security", href: "/topics/api-security" },
-      { label: "Threat Modeling", href: "/topics/threat-modeling" },
-      { label: "Vulnerability Mgmt", href: "/topics/vulnerability-management" },
+      { label: "Application Security", eyebrow: "Curriculum" },
+      { label: "API Security", eyebrow: "Curriculum" },
+      { label: "Threat Modeling", eyebrow: "Curriculum" },
+      { label: "Vulnerability Mgmt", eyebrow: "Curriculum" },
     ],
   },
   {
     title: "Governance",
     items: [
-      { label: "RMF / NIST 800-53", href: "/topics/rmf-800-53" },
-      { label: "ISO 27001", href: "/topics/iso-27001" },
-      { label: "SOC 2", href: "/topics/soc2" },
-      { label: "FedRAMP", href: "/topics/fedramp" },
+      { label: "RMF / NIST 800-53", eyebrow: "Curriculum" },
+      { label: "ISO 27001", eyebrow: "Curriculum" },
+      { label: "SOC 2", eyebrow: "Curriculum" },
+      { label: "FedRAMP", eyebrow: "Curriculum" },
     ],
   },
 ];
 
 const toolsSpotlight = [
-  { label: "Nmap", href: "/tools/nmap" },
-  { label: "Burp Suite", href: "/tools/burp-suite" },
-  { label: "Wireshark", href: "/tools/wireshark" },
-  { label: "Trivy", href: "/tools/trivy" },
-  { label: "Prowler", href: "/tools/prowler" },
-  { label: "HashiCorp Vault", href: "/tools/vault" },
+  { label: "Nmap", eyebrow: "Lab Preview" },
+  { label: "Burp Suite", eyebrow: "Lab Preview" },
+  { label: "Wireshark", eyebrow: "Lab Preview" },
+  { label: "Trivy", eyebrow: "Lab Preview" },
+  { label: "Prowler", eyebrow: "Lab Preview" },
+  { label: "HashiCorp Vault", eyebrow: "Lab Preview" },
 ];
 
 export default function HomeLanding() {
@@ -96,13 +96,14 @@ export default function HomeLanding() {
             <div className="w-full md:w-auto">
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
                 {quickLinks.map((q) => (
-                  <Link
+                  <PromoFlare
                     key={q.k}
-                    href={q.href}
-                    className="rounded-xl border border-slate-800 bg-slate-900 hover:bg-slate-800 px-4 py-3 text-slate-100 hover:text-emerald-400 transition text-sm text-center"
-                  >
-                    {q.label}
-                  </Link>
+                    label={q.label}
+                    eyebrow={q.eyebrow}
+                    size="lg"
+                    align="center"
+                    className="h-full"
+                  />
                 ))}
               </div>
             </div>
@@ -117,12 +118,10 @@ export default function HomeLanding() {
           {topicBuckets.map((b) => (
             <div key={b.title} className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
               <h3 className="text-sm uppercase tracking-wide text-emerald-400 mb-2">{b.title}</h3>
-              <ul className="space-y-1 text-sm">
+              <ul className="space-y-2 text-sm">
                 {b.items.map((it) => (
-                  <li key={it.href}>
-                    <Link href={it.href} className="text-slate-200 hover:text-emerald-400">
-                      {it.label}
-                    </Link>
+                  <li key={it.label}>
+                    <PromoFlare label={it.label} eyebrow={it.eyebrow ?? "Curriculum"} size="sm" />
                   </li>
                 ))}
               </ul>
@@ -136,19 +135,17 @@ export default function HomeLanding() {
         <div className="mx-auto max-w-6xl px-4 py-12 md:py-16">
           <div className="flex items-center justify-between mb-6">
             <h2 className="text-xl font-semibold">Popular Tools</h2>
-            <Link href="/tools" className="text-sm text-emerald-400 hover:underline underline-offset-4">
-              View all
-            </Link>
+            <PromoBadge label="Full catalog in preview" tone="active" />
           </div>
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3">
             {toolsSpotlight.map((t) => (
-              <Link
-                key={t.href}
-                href={t.href}
-                className="rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-center text-slate-200 hover:text-emerald-400 hover:border-emerald-600 transition text-sm"
-              >
-                {t.label}
-              </Link>
+              <PromoFlare
+                key={t.label}
+                label={t.label}
+                eyebrow={t.eyebrow}
+                size="sm"
+                align="center"
+              />
             ))}
           </div>
         </div>

--- a/iron-codex-w3-w3schools-next/components/IronHeader.data.tsx
+++ b/iron-codex-w3-w3schools-next/components/IronHeader.data.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useState } from "react";
 import nav from "@/data/nav.json";
+import { PromoBadge } from "./PromoFlare";
 
 export default function NavBar(){
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -8,19 +9,21 @@ export default function NavBar(){
   return (
     <header className="sticky top-0 z-50 bg-slate-900/80 backdrop-blur border-b border-slate-800">
       <div className="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
-        <a href="/" className="font-semibold">Iron Codex</a>
+        <PromoBadge label="Iron Codex" tone="active" className="text-base" />
         <nav className="hidden md:flex gap-3">
           {items.map((it) => (
-            <a key={it.href} href={it.href} className="px-3 py-1.5 rounded-md hover:bg-slate-800">{it.label}</a>
+            <PromoBadge key={it.href} label={it.label} className="px-4 py-2" />
           ))}
         </nav>
         <button className="md:hidden px-3 py-1.5 rounded" onClick={()=>setMobileOpen(v=>!v)}>Menu</button>
       </div>
       {mobileOpen && (
         <div className="md:hidden border-t border-slate-800 p-2">
-          {(nav?.items || []).map((it)=>(
-            <a key={it.href} href={it.href} className="block px-3 py-2 rounded hover:bg-slate-800">{it.label}</a>
-          ))}
+          <div className="space-y-2">
+            {(nav?.items || []).map((it)=>(
+              <PromoBadge key={it.href} label={it.label} className="w-full justify-center" />
+            ))}
+          </div>
         </div>
       )}
     </header>

--- a/iron-codex-w3-w3schools-next/components/IronHeader.tsx
+++ b/iron-codex-w3-w3schools-next/components/IronHeader.tsx
@@ -14,9 +14,9 @@ const secondaryLinks: [string, string][] = [
   ["Network Security", "/topics/network-security/intro"],
   ["Identity & Access", "/topics/identity-access-management/intro"],
   ["Containers & K8s", "/topics/container-security/intro"],
-  ["Incident Response", "/guides/incident-response"],
-  ["Vendor Reviews", "/guides/saas-security"],
-  ["SaaS Security", "/guides/saas-security"],
+  ["Incident Response", "/guides/incident-response/intro"],
+  ["Vendor Reviews", "/guides/saas-security/intro"],
+  ["SaaS Security", "/guides/saas-security/intro"],
   ["Crypto & Key Mgmt", "/topics/cryptography/intro"],
   ["Logging & Monitoring", "/topics/logging-and-monitoring/intro"],
   ["GenAI Security", "/topics/ai-ml-security/intro"],
@@ -41,7 +41,12 @@ function MenuCol({ title, items }: { title: string; items: [string, string][] })
       <ul className="space-y-1 text-sm">
         {items.map(([label, href]) => (
           <li key={href}>
-            <a href={href} className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400 transition">{label}</a>
+            <Link
+              href={href}
+              className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400 transition"
+            >
+              {label}
+            </Link>
           </li>
         ))}
       </ul>
@@ -83,10 +88,10 @@ export default function NavBar() {
             {/* Invisible hover bridge */}
             <div className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 top-full h-2 w-full z-[59]"></div>
             <div className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition absolute left-1/2 -translate-x-1/2 mt-2 z-[60] w-[820px] max-w-[95vw] px-2 sm:px-0 rounded-xl border border-slate-700 bg-slate-800 shadow-xl ring-1 ring-slate-700 p-4 grid grid-cols-2 sm:grid-cols-4 gap-5">
-              <MenuCol title="Fundamentals" items={[["Security Fundamentals","/topics/security-fundamentals"],["Identity & Access","/topics/identity-access"],["Cryptography","/topics/cryptography"],["Risk Management","/topics/risk-management"]]} />
-              <MenuCol title="Network & Infra" items={[["Network Security","/topics/network-security"],["Cloud Security","/topics/cloud-security"],["Endpoint Security","/topics/endpoints"],["Supply Chain","/topics/supply-chain"]]} />
-              <MenuCol title="AppSec" items={[["Application Security","/topics/application-security/intro"],["API Security","/topics/api-security"],["Threat Modeling","/topics/threat-modeling"],["Vulnerability Mgmt","/topics/vuln-management"]]} />
-              <MenuCol title="Governance" items={[["RMF / NIST 800-53","/topics/rmf-800-53"],["ISO 27001","/topics/iso-27001"],["SOC 2","/topics/soc2"],["FedRAMP","/topics/fedramp"]]} />
+              <MenuCol title="Fundamentals" items={[["Security Fundamentals","/topics/security-fundamentals/intro"],["Identity & Access","/topics/identity-access-management/intro"],["Cryptography","/topics/cryptography/intro"],["Risk Management","/topics/governance-risk-compliance/intro"]]} />
+              <MenuCol title="Network & Infra" items={[["Network Security","/topics/network-security/intro"],["Cloud Security","/topics/cloud-security/intro"],["Endpoint Security","/topics/endpoint-security/intro"],["Supply Chain","/topics/supply-chain-security/intro"]]} />
+              <MenuCol title="AppSec" items={[["Application Security","/topics/application-security/intro"],["API Security","/topics/api-security/intro"],["Threat Modeling","/topics/threat-modeling/intro"],["Vulnerability Mgmt","/topics/vulnerability-management/intro"]]} />
+              <MenuCol title="Governance" items={[["RMF / NIST 800-53","/topics/governance-risk-compliance/intro"],["ISO 27001","/topics/compliance-audit/intro"],["SOC 2","/topics/compliance-audit/intro"],["FedRAMP","/topics/governance-risk-compliance/intro"]]} />
             </div>
           </div>
 
@@ -96,11 +101,11 @@ export default function NavBar() {
             {/* Invisible hover bridge */}
             <div className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 top-full h-2 w-full z-[59]"></div>
             <div className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition absolute left-1/2 -translate-x-1/2 mt-2 z-[60] w-[360px] max-w-[95vw] px-2 sm:px-0 rounded-xl border border-slate-700 bg-slate-800 shadow-xl ring-1 ring-slate-700 p-3 grid grid-cols-1 gap-1">
-              <a href="/topics/api-security/intro" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Deep Dive: API Security</a>
-              <a href="/topics/cloud-security/intro" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Cloud Hardening</a>
-              <a href="/guides/saas-security" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Vendor/SaaS Reviews</a>
-              <a href="/guides/incident-response" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Incident Response</a>
-              <a href="/topics/zero-trust/intro" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Zero Trust</a>
+              <Link href="/guides/api-security/intro" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Deep Dive: API Security</Link>
+              <Link href="/guides/cloud-security/intro" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Cloud Hardening</Link>
+              <Link href="/guides/saas-security/intro" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Vendor/SaaS Reviews</Link>
+              <Link href="/guides/incident-response/intro" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Incident Response</Link>
+              <Link href="/topics/zero-trust/intro" className="block px-2 py-1 rounded text-slate-100 hover:bg-emerald-600/20 hover:text-emerald-400">Zero Trust</Link>
             </div>
           </div>
 

--- a/iron-codex-w3-w3schools-next/components/PromoFlare.tsx
+++ b/iron-codex-w3-w3schools-next/components/PromoFlare.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+export type PromoFlareProps = {
+  label: ReactNode;
+  eyebrow?: ReactNode;
+  tone?: "default" | "active";
+  size?: "sm" | "md" | "lg";
+  align?: "left" | "center";
+  className?: string;
+};
+
+export function PromoFlare({
+  label,
+  eyebrow = "Preview Mode",
+  tone = "default",
+  size = "md",
+  align = "left",
+  className = "",
+}: PromoFlareProps) {
+  const base = "w-full select-none cursor-default rounded-xl border bg-slate-900/60 shadow-inner";
+  const toneClass =
+    tone === "active"
+      ? "border-emerald-400/70 bg-emerald-500/10 text-emerald-100 shadow-[0_0_20px_rgba(16,185,129,0.25)]"
+      : "border-slate-800/70 text-slate-300";
+  const sizeClass =
+    size === "lg"
+      ? "px-5 py-4 text-base"
+      : size === "sm"
+        ? "px-3 py-2 text-xs"
+        : "px-4 py-3 text-sm";
+  const alignClass = align === "center" ? "text-center" : "text-left";
+
+  return (
+    <div className={`${base} ${toneClass} ${sizeClass} ${alignClass} ${className}`.trim()}>
+      <div className="font-semibold leading-tight">{label}</div>
+      {eyebrow ? (
+        <div className="mt-1 text-[10px] uppercase tracking-[0.32em] text-emerald-300/70">{eyebrow}</div>
+      ) : null}
+    </div>
+  );
+}
+
+export function PromoBadge({
+  label,
+  tone = "default",
+  className = "",
+}: {
+  label: ReactNode;
+  tone?: "default" | "active";
+  className?: string;
+}) {
+  const base = "inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold tracking-wide";
+  const toneClass =
+    tone === "active"
+      ? "bg-emerald-500/20 text-emerald-100 border border-emerald-400/70 shadow-[0_0_14px_rgba(16,185,129,0.3)]"
+      : "bg-slate-800/60 text-slate-300 border border-slate-700/70";
+  return <span className={`${base} ${toneClass} ${className}`.trim()}>{label}</span>;
+}

--- a/iron-codex-w3-w3schools-next/components/Tiles.tsx
+++ b/iron-codex-w3-w3schools-next/components/Tiles.tsx
@@ -1,11 +1,11 @@
 export default function Tiles(){
   const tiles = [
-    { href: "/topics/api-security", title: "API Security", desc: "JWT, scopes, rate‑limits", color: "bg-lime-200" },
-    { href: "/topics/cloud-security", title: "Cloud Security", desc: "S3, KMS, IAM, VPC", color: "bg-blue-200" },
-    { href: "/topics/identity-access", title: "Identity & Access", desc: "OIDC, SSO, MFA, RBAC", color: "bg-yellow-200" },
-    { href: "/topics/container-security", title: "Container Security", desc: "Images, runtime, policies", color: "bg-pink-200" },
-    { href: "/topics/saas-security", title: "SaaS Security", desc: "DLP, SSO, SCIM", color: "bg-purple-200" },
-    { href: "/topics/zero-trust", title: "Zero Trust", desc: "mTLS, device trust", color: "bg-teal-200" },
+    { title: "API Security", desc: "JWT, scopes, rate‑limits", color: "bg-lime-200" },
+    { title: "Cloud Security", desc: "S3, KMS, IAM, VPC", color: "bg-blue-200" },
+    { title: "Identity & Access", desc: "OIDC, SSO, MFA, RBAC", color: "bg-yellow-200" },
+    { title: "Container Security", desc: "Images, runtime, policies", color: "bg-pink-200" },
+    { title: "SaaS Security", desc: "DLP, SSO, SCIM", color: "bg-purple-200" },
+    { title: "Zero Trust", desc: "mTLS, device trust", color: "bg-teal-200" },
   ];
   return (
     <section className="py-14 bg-white">
@@ -13,10 +13,10 @@ export default function Tiles(){
         <h2 className="text-2xl md:text-3xl text-blue-900 font-medium text-center mb-6">Explore Major Topics</h2>
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
           {tiles.map(t => (
-            <a key={t.title} href={t.href} className={`tile ${t.color}`}>
+            <div key={t.title} className={`tile ${t.color}`}>
               <h3 className="text-lg font-semibold mb-1">{t.title}</h3>
               <p className="opacity-90">{t.desc}</p>
-            </a>
+            </div>
           ))}
         </div>
       </div>

--- a/iron-codex-w3-w3schools-next/components/TopicShell.tsx
+++ b/iron-codex-w3-w3schools-next/components/TopicShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useMemo, useState } from "react";
-import Link from "next/link";
+import { PromoFlare } from "./PromoFlare";
 
 export type TOCItem = { id: string; label: string };
 export type TOCGroup = [string, TOCItem[]];
@@ -58,17 +58,13 @@ export default function TopicShell({
                 <div className="text-xs uppercase tracking-wide text-slate-400 px-3 pt-2">{group}</div>
                 <div className="p-2 space-y-1">
                   {items.map((item) => (
-                    <Link
+                    <PromoFlare
                       key={item.id}
-                      href={`/${kind}/${topic}/${item.id}`}
-                      className={`block px-3 py-1.5 rounded-md border transition-colors ${
-                        slug === item.id
-                          ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-300"
-                          : "border-transparent hover:border-slate-700 text-slate-300 hover:text-slate-200"
-                      }`}
-                    >
-                      {item.label}
-                    </Link>
+                      label={item.label}
+                      tone={slug === item.id ? "active" : "default"}
+                      eyebrow="Preview Series"
+                      size="sm"
+                    />
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add shared PromoFlare/PromoBadge components for static promotional UI
- point header topic and guide links at their /intro routes and render them with Next Link
- replace body navigation links across landing pages, clients, and tools with promotional flare layouts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1c4261a288322a7086e79a44ed8ee