### PR TITLE
Refresh Iron Codex branding with new logo

### DIFF
--- a/iron-codex/_templates/simple_template_system.html
+++ b/iron-codex/_templates/simple_template_system.html
@@ -12,7 +12,10 @@
     <!-- HEADER - Keep this identical across all guides -->
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/about.html
+++ b/iron-codex/about.html
@@ -10,7 +10,10 @@
 <body data-page="about">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo" aria-label="Iron Codex home">
+                <img src="assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>
@@ -235,7 +238,11 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>🛡️ Iron Codex</h3>
+                    
+                    <h3 class="footer-logo">
+                        <img src="assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                        <span class="logo-text">Iron Codex Cybersecurity</span>
+                    </h3>
                     <p>Practical cybersecurity guidance for security professionals.</p>
                 </div>
                 <div class="footer-section">

--- a/iron-codex/assets/css/main.css
+++ b/iron-codex/assets/css/main.css
@@ -1,4 +1,5 @@
 /* Iron Codex - Complete Main Stylesheet */
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&display=swap');
 
 /* CSS Variables */
 :root {
@@ -16,6 +17,8 @@
     --glass-border: rgba(255, 255, 255, 0.2);
     --shadow: rgba(0, 0, 0, 0.3);
     --gradient: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+    --brand-text: #e5f3ff;
+    --brand-glow: rgba(0, 212, 255, 0.35);
 }
 
 /* Reset & Base Styles */
@@ -81,14 +84,102 @@ a:hover {
     padding: 1rem 0;
 }
 
-.logo {
-    font-size: 1.8rem;
-    font-weight: bold;
-    color: var(--accent);
-    text-decoration: none;
-    display: flex;
+.logo,
+.footer-logo {
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.75rem;
+    color: var(--brand-text);
+    text-decoration: none;
+    letter-spacing: 0.12em;
+}
+
+.logo {
+    font-family: 'Cinzel', 'Times New Roman', serif;
+    font-size: 1.4rem;
+    font-weight: 700;
+    transition: color 0.3s ease;
+}
+
+.logo:visited {
+    color: var(--brand-text);
+}
+
+.logo:hover {
+    color: var(--accent);
+}
+
+.logo-icon {
+    width: 42px;
+    height: 42px;
+    flex-shrink: 0;
+    filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.45));
+    transition: transform 0.3s ease, filter 0.3s ease;
+}
+
+.footer-logo .logo-icon {
+    width: 36px;
+    height: 36px;
+    filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.4));
+}
+
+.logo-text {
+    font-family: 'Cinzel', 'Times New Roman', serif;
+    font-size: 1.3rem;
+    color: var(--brand-text);
+    text-shadow: 0 2px 4px rgba(5, 10, 30, 0.8), 0 0 18px var(--brand-glow);
+    white-space: nowrap;
+    transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+
+.footer-logo {
+    font-family: 'Cinzel', 'Times New Roman', serif;
+    font-weight: 600;
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+    margin-top: 0;
+    line-height: 1.2;
+}
+
+.footer-logo .logo-text {
+    font-size: 1.1rem;
+}
+
+.logo:hover .logo-text {
+    color: var(--accent);
+    text-shadow: 0 3px 8px rgba(5, 10, 30, 0.85), 0 0 22px rgba(0, 212, 255, 0.55);
+}
+
+.logo:hover .logo-icon {
+    transform: translateY(-1px) scale(1.02);
+    filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.5));
+}
+
+@media (max-width: 768px) {
+    .logo {
+        font-size: 1.1rem;
+        gap: 0.5rem;
+    }
+
+    .logo-icon {
+        width: 34px;
+        height: 34px;
+    }
+
+    .logo-text {
+        font-size: 1.05rem;
+        letter-spacing: 0.08em;
+    }
+
+    .footer-logo {
+        font-size: 1.05rem;
+        gap: 0.5rem;
+    }
+
+    .footer-logo .logo-icon {
+        width: 30px;
+        height: 30px;
+    }
 }
 
 .nav-menu {
@@ -548,6 +639,26 @@ a:hover {
 @media (max-width: 480px) {
     .container {
         padding: 0 15px;
+    }
+
+    .logo {
+        font-size: 1rem;
+    }
+
+    .logo-icon {
+        width: 28px;
+        height: 28px;
+    }
+
+    .logo-text {
+        font-size: 0.95rem;
+        letter-spacing: 0.06em;
+        white-space: normal;
+        line-height: 1.25;
+    }
+
+    .footer-logo {
+        font-size: 1rem;
     }
 
     .hero {

--- a/iron-codex/assets/img/iron-book-logo.svg
+++ b/iron-codex/assets/img/iron-book-logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 64 64" role="img" aria-label="Iron Codex logo">
+  <defs>
+    <linearGradient id="steel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#d1d5db"/>
+      <stop offset="50%" stop-color="#9ca3af"/>
+      <stop offset="100%" stop-color="#6b7280"/>
+    </linearGradient>
+  </defs>
+  <path d="M12 10h30a6 6 0 0 1 6 6v32a6 6 0 0 1-6 6H12z" fill="url(#steel)" stroke="#4b5563" stroke-width="1.5" />
+  <path d="M12 10h22c4 0 7 3 7 7v31c0 0-3-4-7-4H12z" fill="#f3f4f6" stroke="#9ca3af" stroke-width="1" />
+  <rect x="12" y="10" width="3" height="34" fill="#9ca3af" opacity="0.5"/>
+  <path d="M41 22c0 7-3.5 12-9 14-5.5-2-9-7-9-14l9-4 9 4z" fill="#374151" stroke="#111827" stroke-width="1"/>
+  <path d="M32 28l-3 3 5 5" fill="none" stroke="#10b981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/iron-codex/assets/js/main.js
+++ b/iron-codex/assets/js/main.js
@@ -187,4 +187,4 @@ window.IronCodex = {
     debounce
 };
 
-console.log('🛡️ Iron Codex loaded successfully!');
+console.log('📘 Iron Codex Cybersecurity assets loaded successfully.');

--- a/iron-codex/guides.html
+++ b/iron-codex/guides.html
@@ -10,7 +10,10 @@
 <body data-page="guides">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo" aria-label="Iron Codex home">
+                <img src="assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>
@@ -231,7 +234,7 @@
                     <p>We're actively developing additional deep dive guides based on community feedback and emerging security challenges.</p>
                     <div class="upcoming-list">
                         <div class="upcoming-item">
-                            <span class="upcoming-icon">🛡️</span>
+                            <span class="upcoming-icon" aria-hidden="true">📘</span>
                             <span>Zero Trust Architecture Implementation</span>
                         </div>
                         <div class="upcoming-item">
@@ -252,7 +255,11 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>🛡️ Iron Codex</h3>
+                    
+                    <h3 class="footer-logo">
+                        <img src="assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                        <span class="logo-text">Iron Codex Cybersecurity</span>
+                    </h3>
                     <p>Practical cybersecurity guidance for security professionals.</p>
                 </div>
                 <div class="footer-section">

--- a/iron-codex/guides/api-security.html
+++ b/iron-codex/guides/api-security.html
@@ -10,7 +10,10 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>
@@ -1025,7 +1028,11 @@ const server = new ApolloServer({
         <div class="container">
             <div class="footer-content">
                 <div class="footer-brand">
-                    <h3>🛡️ Iron Codex</h3>
+                    
+                    <h3 class="footer-logo">
+                        <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                        <span class="logo-text">Iron Codex Cybersecurity</span>
+                    </h3>
                     <p>Your comprehensive cybersecurity learning platform</p>
                 </div>
                 <div class="footer-links">

--- a/iron-codex/guides/cloud-security.html
+++ b/iron-codex/guides/cloud-security.html
@@ -10,7 +10,10 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/containers.html
+++ b/iron-codex/guides/containers.html
@@ -10,7 +10,10 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/iam.html
+++ b/iron-codex/guides/iam.html
@@ -10,7 +10,10 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/incident-response.html
+++ b/iron-codex/guides/incident-response.html
@@ -10,7 +10,10 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/saas-security.html
+++ b/iron-codex/guides/saas-security.html
@@ -10,7 +10,10 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/index.html
+++ b/iron-codex/index.html
@@ -10,7 +10,10 @@
 <body>
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo" aria-label="Iron Codex home">
+                <img src="assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link active">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>
@@ -160,7 +163,11 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>🛡️ Iron Codex</h3>
+                    
+                    <h3 class="footer-logo">
+                        <img src="assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                        <span class="logo-text">Iron Codex Cybersecurity</span>
+                    </h3>
                     <p>Practical cybersecurity guidance for security professionals.</p>
                 </div>
                 <div class="footer-section">

--- a/iron-codex/tools.html
+++ b/iron-codex/tools.html
@@ -10,7 +10,10 @@
 <body data-page="tools">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo" aria-label="Iron Codex home">
+                <img src="assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>
@@ -345,7 +348,11 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h3>🛡️ Iron Codex</h3>
+                    
+                    <h3 class="footer-logo">
+                        <img src="assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                        <span class="logo-text">Iron Codex Cybersecurity</span>
+                    </h3>
                     <p>Practical cybersecurity guidance for security professionals.</p>
                 </div>
                 <div class="footer-section">

--- a/iron-codex/topics.html
+++ b/iron-codex/topics.html
@@ -245,7 +245,10 @@
 <body data-page="topics">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo" aria-label="Iron Codex home">
+                <img src="assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/api-security.html
+++ b/iron-codex/topics/api-security.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/business-continuity.html
+++ b/iron-codex/topics/business-continuity.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/cloud-security.html
+++ b/iron-codex/topics/cloud-security.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/compliance-audit.html
+++ b/iron-codex/topics/compliance-audit.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/container-security.html
+++ b/iron-codex/topics/container-security.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/cryptography.html
+++ b/iron-codex/topics/cryptography.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/data-protection.html
+++ b/iron-codex/topics/data-protection.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/devsecops.html
+++ b/iron-codex/topics/devsecops.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/digital-forensics.html
+++ b/iron-codex/topics/digital-forensics.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/email-security.html
+++ b/iron-codex/topics/email-security.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/endpoint-security.html
+++ b/iron-codex/topics/endpoint-security.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/identity-access-management.html
+++ b/iron-codex/topics/identity-access-management.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/incident-response.html
+++ b/iron-codex/topics/incident-response.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/mobile-security.html
+++ b/iron-codex/topics/mobile-security.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/network-security.html
+++ b/iron-codex/topics/network-security.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/physical-security.html
+++ b/iron-codex/topics/physical-security.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/red-team-operations.html
+++ b/iron-codex/topics/red-team-operations.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/security-awareness.html
+++ b/iron-codex/topics/security-awareness.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/security-fundamentals.html
+++ b/iron-codex/topics/security-fundamentals.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/threat-intelligence.html
+++ b/iron-codex/topics/threat-intelligence.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/web-application-security.html
+++ b/iron-codex/topics/web-application-security.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/zero-trust.html
+++ b/iron-codex/topics/zero-trust.html
@@ -10,7 +10,10 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo" aria-label="Iron Codex home">
+                <img src="../assets/img/iron-book-logo.svg" alt="Iron Codex" class="logo-icon">
+                <span class="logo-text">Iron Codex Cybersecurity</span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>


### PR DESCRIPTION
## Summary
- add the Iron Codex book logo asset and replace header/footer branding across the site to show the image with the product name
- restyle the logo treatment with a Cinzel web font, embossed text-shadow, and responsive sizing so the new branding reads well on desktop and mobile
- swap remaining shield references (guide teaser icon, console log) to use the new book-themed motif

## Testing
- python -m http.server 8000 & curl -I http://127.0.0.1:8000/index.html
- curl -I http://127.0.0.1:8000/assets/img/iron-book-logo.svg

------
https://chatgpt.com/codex/tasks/task_e_68d1f8f2d8e483228580438e091811ed