### PR TITLE
Replace Iron Codex header logo with SVG artwork

### DIFF
--- a/iron-codex/_templates/simple_template_system.html
+++ b/iron-codex/_templates/simple_template_system.html
@@ -12,7 +12,7 @@
     <!-- HEADER - Keep this identical across all guides -->
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/about.html
+++ b/iron-codex/about.html
@@ -10,7 +10,7 @@
 <body data-page="about">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo"><img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/assets/css/main.css
+++ b/iron-codex/assets/css/main.css
@@ -91,6 +91,13 @@ a:hover {
     gap: 0.5rem;
 }
 
+.logo-image {
+    width: 2.25rem;
+    height: auto;
+    display: block;
+    flex-shrink: 0;
+}
+
 .nav-menu {
     display: flex;
     list-style: none;

--- a/iron-codex/assets/images/iron-codex-logo.svg
+++ b/iron-codex/assets/images/iron-codex-logo.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title desc">
+  <title id="title">Iron Codex logo</title>
+  <desc id="desc">Stylized digital book with a secure lock emblem</desc>
+  <defs>
+    <linearGradient id="coverGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#2f3a84" />
+      <stop offset="100%" stop-color="#141a3a" />
+    </linearGradient>
+    <linearGradient id="pageGradient" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
+      <stop offset="50%" stop-color="#dce3ff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#b8c4ff" stop-opacity="0.9" />
+    </linearGradient>
+    <linearGradient id="lockGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffdf71" />
+      <stop offset="100%" stop-color="#ffb341" />
+    </linearGradient>
+    <clipPath id="bookClip">
+      <rect x="22" y="24" width="76" height="72" rx="10" ry="10" />
+    </clipPath>
+  </defs>
+  <rect x="12" y="12" width="96" height="96" rx="20" fill="url(#coverGradient)" />
+  <g clip-path="url(#bookClip)">
+    <rect x="26" y="28" width="32" height="64" rx="6" fill="url(#pageGradient)" />
+    <rect x="62" y="28" width="32" height="64" rx="6" fill="#d1dcff" opacity="0.9" />
+    <rect x="58" y="28" width="4" height="64" fill="#a2b1ff" />
+    <path d="M36 40h16M36 54h16M36 68h16" fill="none" stroke="#8ea0ff" stroke-width="3" stroke-linecap="round" />
+    <path d="M68 44h16M68 58h16" fill="none" stroke="#9bb0ff" stroke-width="3" stroke-linecap="round" />
+  </g>
+  <g transform="translate(0,-2)">
+    <path d="M60 44c-7.2 0-13 5.8-13 13v6h26v-6c0-7.2-5.8-13-13-13z" fill="#f5f7ff" />
+    <rect x="47" y="61" width="26" height="27" rx="7" fill="url(#lockGradient)" />
+    <circle cx="60" cy="74" r="5" fill="#2f3a84" />
+    <rect x="58.5" y="74" width="3" height="9" rx="1.5" fill="#2f3a84" />
+  </g>
+  <g fill="#7fa4ff">
+    <circle cx="32" cy="96" r="3" />
+    <circle cx="88" cy="32" r="3" />
+    <rect x="85" y="94" width="12" height="3" rx="1.5" />
+    <rect x="28" y="30" width="10" height="3" rx="1.5" />
+  </g>
+</svg>

--- a/iron-codex/guides.html
+++ b/iron-codex/guides.html
@@ -10,7 +10,7 @@
 <body data-page="guides">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo"><img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/api-security.html
+++ b/iron-codex/guides/api-security.html
@@ -10,7 +10,7 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/cloud-security.html
+++ b/iron-codex/guides/cloud-security.html
@@ -10,7 +10,7 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/containers.html
+++ b/iron-codex/guides/containers.html
@@ -10,7 +10,7 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/iam.html
+++ b/iron-codex/guides/iam.html
@@ -10,7 +10,7 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/incident-response.html
+++ b/iron-codex/guides/incident-response.html
@@ -10,7 +10,7 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/saas-security.html
+++ b/iron-codex/guides/saas-security.html
@@ -10,7 +10,7 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/index.html
+++ b/iron-codex/index.html
@@ -10,7 +10,7 @@
 <body>
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo"><img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link active">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/tools.html
+++ b/iron-codex/tools.html
@@ -10,7 +10,7 @@
 <body data-page="tools">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo"><img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/topics.html
+++ b/iron-codex/topics.html
@@ -245,7 +245,7 @@
 <body data-page="topics">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo"><img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/api-security.html
+++ b/iron-codex/topics/api-security.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/business-continuity.html
+++ b/iron-codex/topics/business-continuity.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/cloud-security.html
+++ b/iron-codex/topics/cloud-security.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/compliance-audit.html
+++ b/iron-codex/topics/compliance-audit.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/container-security.html
+++ b/iron-codex/topics/container-security.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/cryptography.html
+++ b/iron-codex/topics/cryptography.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/data-protection.html
+++ b/iron-codex/topics/data-protection.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/devsecops.html
+++ b/iron-codex/topics/devsecops.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/digital-forensics.html
+++ b/iron-codex/topics/digital-forensics.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/email-security.html
+++ b/iron-codex/topics/email-security.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/endpoint-security.html
+++ b/iron-codex/topics/endpoint-security.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/identity-access-management.html
+++ b/iron-codex/topics/identity-access-management.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/incident-response.html
+++ b/iron-codex/topics/incident-response.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/mobile-security.html
+++ b/iron-codex/topics/mobile-security.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/network-security.html
+++ b/iron-codex/topics/network-security.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/physical-security.html
+++ b/iron-codex/topics/physical-security.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/red-team-operations.html
+++ b/iron-codex/topics/red-team-operations.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/security-awareness.html
+++ b/iron-codex/topics/security-awareness.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/security-fundamentals.html
+++ b/iron-codex/topics/security-fundamentals.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/threat-intelligence.html
+++ b/iron-codex/topics/threat-intelligence.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/web-application-security.html
+++ b/iron-codex/topics/web-application-security.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/zero-trust.html
+++ b/iron-codex/topics/zero-trust.html
@@ -10,7 +10,7 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo"><img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">Iron Codex</a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>


### PR DESCRIPTION
## Summary
- add a text-friendly SVG recreation of the Iron Codex logo and ensure no PNG assets remain in the branch
- switch every header logo reference to the new SVG and keep the template in sync for future pages
- style the shared `.logo-image` class so the new artwork aligns within the existing navigation layout

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d81f26f8f48322882fed8cf83d936f