### PR TITLE
Refresh Iron Codex header branding with SVG logo

### DIFF
--- a/iron-codex/_templates/simple_template_system.html
+++ b/iron-codex/_templates/simple_template_system.html
@@ -12,7 +12,16 @@
     <!-- HEADER - Keep this identical across all guides -->
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/about.html
+++ b/iron-codex/about.html
@@ -10,7 +10,16 @@
 <body data-page="about">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo">
+                <img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/assets/css/main.css
+++ b/iron-codex/assets/css/main.css
@@ -16,6 +16,11 @@
     --glass-border: rgba(255, 255, 255, 0.2);
     --shadow: rgba(0, 0, 0, 0.3);
     --gradient: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+    --header-height: 80px;
+    --logo-glow: rgba(83, 214, 255, 0.45);
+    --logo-title: #67d8ff;
+    --logo-title-secondary: #8be9ff;
+    --logo-subtitle: #58a6ff;
 }
 
 /* Reset & Base Styles */
@@ -72,44 +77,120 @@ a:hover {
     position: sticky;
     top: 0;
     z-index: 1000;
+    min-height: var(--header-height);
+    display: flex;
+    align-items: center;
 }
 
 .nav {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1rem 0;
+    gap: 1.5rem;
+    padding: 0.75rem 0;
+    min-height: var(--header-height);
 }
 
 .logo {
-    font-size: 1.8rem;
-    font-weight: bold;
-    color: var(--accent);
-    text-decoration: none;
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.75rem;
+    color: var(--text);
+    text-decoration: none;
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.logo:hover {
+    color: var(--text);
+}
+
+.logo:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 4px;
+}
+
+.logo-image {
+    height: 44px;
+    width: auto;
+    display: block;
+    border-radius: 10px;
+    filter: drop-shadow(0 0 12px var(--logo-glow));
+}
+
+.logo-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    text-transform: uppercase;
+    line-height: 1;
+    letter-spacing: 0.1em;
+}
+
+.logo-title {
+    display: flex;
+    flex-direction: column;
+    font-size: 1.05rem;
+    letter-spacing: 0.32em;
+    color: var(--logo-title);
+    text-shadow: 0 0 10px var(--logo-glow);
+}
+
+.logo-title span {
+    display: block;
+    line-height: 0.9;
+}
+
+.logo-title span:last-child {
+    color: var(--logo-title-secondary);
+    letter-spacing: 0.28em;
+}
+
+.logo-subtitle {
+    font-size: 0.55rem;
+    font-weight: 600;
+    letter-spacing: 0.48em;
+    color: var(--logo-subtitle);
 }
 
 .nav-menu {
     display: flex;
     list-style: none;
-    gap: 2rem;
+    gap: 1.75rem;
 }
 
 .nav-link {
-    color: var(--text);
+    position: relative;
+    color: var(--text-muted);
     text-decoration: none;
-    font-weight: 500;
-    padding: 0.5rem 1rem;
-    border-radius: 8px;
-    transition: all 0.3s ease;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    padding: 0.35rem 0;
+    transition: color 0.3s ease;
+}
+
+.nav-link::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: -0.4rem;
+    width: 0;
+    height: 2px;
+    background: var(--accent);
+    transition: width 0.3s ease, left 0.3s ease;
+    border-radius: 999px;
 }
 
 .nav-link:hover,
 .nav-link.active {
     color: var(--accent);
-    background: var(--glass);
+}
+
+.nav-link:hover::after,
+.nav-link.active::after {
+    width: 100%;
+    left: 0;
 }
 
 .nav-toggle {
@@ -481,10 +562,10 @@ a:hover {
 @media (max-width: 768px) {
     .nav-menu {
         position: fixed;
-        top: 70px;
+        top: var(--header-height);
         left: -100%;
         width: 100%;
-        height: calc(100vh - 70px);
+        height: calc(100vh - var(--header-height));
         background: rgba(10, 14, 39, 0.98);
         backdrop-filter: blur(20px);
         flex-direction: column;
@@ -492,6 +573,22 @@ a:hover {
         justify-content: flex-start;
         padding: 2rem;
         transition: left 0.3s ease;
+    }
+
+    .nav-menu li {
+        width: 100%;
+    }
+
+    .nav-link {
+        width: 100%;
+        text-align: center;
+        font-size: 1.1rem;
+        letter-spacing: 0.2em;
+        padding: 0.75rem 0;
+    }
+
+    .nav-link::after {
+        bottom: 0;
     }
 
     .nav-menu.active {

--- a/iron-codex/assets/images/iron-codex-logo.svg
+++ b/iron-codex/assets/images/iron-codex-logo.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="88" height="44" viewBox="0 0 88 44" role="img" aria-labelledby="title desc">
+  <title id="title">Iron Codex logo</title>
+  <desc id="desc">Stylized digital book with a lock emblem.</desc>
+  <defs>
+    <linearGradient id="bookGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0e1a36" />
+      <stop offset="100%" stop-color="#16365a" />
+    </linearGradient>
+    <linearGradient id="lockGradient" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#78e3ff" />
+      <stop offset="100%" stop-color="#41b8ff" />
+    </linearGradient>
+    <linearGradient id="glowGradient" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#41c2ff" stop-opacity="0" />
+      <stop offset="50%" stop-color="#41c2ff" stop-opacity="0.45" />
+      <stop offset="100%" stop-color="#41c2ff" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="1.5" y="3" width="85" height="38" rx="10" fill="url(#bookGradient)" stroke="#2d71ff" stroke-width="1.5" />
+    <path d="M18 12h20c3.5 0 5.5 1.6 5.5 4.8V31c0 3.2-2 4.8-5.5 4.8H18c-3.5 0-5.5-1.6-5.5-4.8V16.8C12.5 13.6 14.5 12 18 12z" fill="#10294b" stroke="#3ca6ff" stroke-width="1.2" />
+    <path d="M70 12H50c-3.5 0-5.5 1.6-5.5 4.8V31c0 3.2 2 4.8 5.5 4.8h20c3.5 0 5.5-1.6 5.5-4.8V16.8C75.5 13.6 73.5 12 70 12z" fill="#10294b" stroke="#3ca6ff" stroke-width="1.2" />
+    <path d="M44 21h-8" stroke="#3ca6ff" stroke-width="1.2" />
+    <path d="M44 26h-8" stroke="#3ca6ff" stroke-width="1.2" />
+    <path d="M44 31h-8" stroke="#3ca6ff" stroke-width="1.2" />
+    <path d="M44 16h-8" stroke="#3ca6ff" stroke-width="1.2" />
+    <path d="M44 21h8" stroke="#3ca6ff" stroke-width="1.2" />
+    <path d="M44 26h8" stroke="#3ca6ff" stroke-width="1.2" />
+    <path d="M44 31h8" stroke="#3ca6ff" stroke-width="1.2" />
+    <path d="M44 16h8" stroke="#3ca6ff" stroke-width="1.2" />
+    <rect x="36.5" y="17" width="15" height="18" rx="4" fill="url(#lockGradient)" stroke="#0a152c" stroke-width="1" />
+    <path d="M41 18v-2.4c0-3.2 2.4-5.6 5.5-5.6s5.5 2.4 5.5 5.6V18" stroke="#7fe9ff" stroke-width="1.2" />
+    <circle cx="44" cy="26.5" r="3" fill="#0e1a36" stroke="#9cf0ff" stroke-width="1.2" />
+    <path d="M44 29.5v3" stroke="#9cf0ff" stroke-width="1.2" />
+  </g>
+  <rect x="6" y="34" width="76" height="4" fill="url(#glowGradient)" opacity="0.9" />
+  <g stroke="#44c3ff" stroke-width="1" opacity="0.75">
+    <circle cx="14" cy="9" r="1.3" fill="#44c3ff" />
+    <circle cx="74" cy="9" r="1.3" fill="#44c3ff" />
+    <circle cx="14" cy="35" r="1.3" fill="#44c3ff" />
+    <circle cx="74" cy="35" r="1.3" fill="#44c3ff" />
+  </g>
+</svg>

--- a/iron-codex/guides.html
+++ b/iron-codex/guides.html
@@ -10,7 +10,16 @@
 <body data-page="guides">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo">
+                <img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/api-security.html
+++ b/iron-codex/guides/api-security.html
@@ -10,7 +10,16 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/cloud-security.html
+++ b/iron-codex/guides/cloud-security.html
@@ -10,7 +10,16 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/containers.html
+++ b/iron-codex/guides/containers.html
@@ -10,7 +10,16 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/iam.html
+++ b/iron-codex/guides/iam.html
@@ -10,7 +10,16 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/incident-response.html
+++ b/iron-codex/guides/incident-response.html
@@ -10,7 +10,16 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/guides/saas-security.html
+++ b/iron-codex/guides/saas-security.html
@@ -10,7 +10,16 @@
 <body data-page="guide">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/index.html
+++ b/iron-codex/index.html
@@ -10,7 +10,16 @@
 <body>
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo">
+                <img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link active">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/tools.html
+++ b/iron-codex/tools.html
@@ -10,7 +10,16 @@
 <body data-page="tools">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo">
+                <img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link">Topics</a></li>

--- a/iron-codex/topics.html
+++ b/iron-codex/topics.html
@@ -245,7 +245,16 @@
 <body data-page="topics">
     <header class="header">
         <nav class="nav container">
-            <a href="index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="index.html" class="logo">
+                <img src="assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="index.html" class="nav-link">Home</a></li>
                 <li><a href="topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/api-security.html
+++ b/iron-codex/topics/api-security.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/business-continuity.html
+++ b/iron-codex/topics/business-continuity.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/cloud-security.html
+++ b/iron-codex/topics/cloud-security.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/compliance-audit.html
+++ b/iron-codex/topics/compliance-audit.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/container-security.html
+++ b/iron-codex/topics/container-security.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/cryptography.html
+++ b/iron-codex/topics/cryptography.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/data-protection.html
+++ b/iron-codex/topics/data-protection.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/devsecops.html
+++ b/iron-codex/topics/devsecops.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/digital-forensics.html
+++ b/iron-codex/topics/digital-forensics.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/email-security.html
+++ b/iron-codex/topics/email-security.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/endpoint-security.html
+++ b/iron-codex/topics/endpoint-security.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/identity-access-management.html
+++ b/iron-codex/topics/identity-access-management.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/incident-response.html
+++ b/iron-codex/topics/incident-response.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/mobile-security.html
+++ b/iron-codex/topics/mobile-security.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/network-security.html
+++ b/iron-codex/topics/network-security.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/physical-security.html
+++ b/iron-codex/topics/physical-security.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/red-team-operations.html
+++ b/iron-codex/topics/red-team-operations.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/security-awareness.html
+++ b/iron-codex/topics/security-awareness.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/security-fundamentals.html
+++ b/iron-codex/topics/security-fundamentals.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/threat-intelligence.html
+++ b/iron-codex/topics/threat-intelligence.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/web-application-security.html
+++ b/iron-codex/topics/web-application-security.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>

--- a/iron-codex/topics/zero-trust.html
+++ b/iron-codex/topics/zero-trust.html
@@ -10,7 +10,16 @@
 <body data-page="topic">
     <header class="header">
         <nav class="nav container">
-            <a href="../index.html" class="logo">🛡️ Iron Codex</a>
+            <a href="../index.html" class="logo">
+                <img src="../assets/images/iron-codex-logo.svg" alt="Iron Codex logo" class="logo-image">
+                <span class="logo-text">
+                    <strong class="logo-title">
+                        <span>IRON-</span>
+                        <span>CODEX</span>
+                    </strong>
+                    <span class="logo-subtitle">CYBERSECURITY</span>
+                </span>
+            </a>
             <ul class="nav-menu">
                 <li><a href="../index.html" class="nav-link">Home</a></li>
                 <li><a href="../topics.html" class="nav-link active">Topics</a></li>


### PR DESCRIPTION
## Summary
- replace the PNG header asset with a new vector iron-codex-logo.svg that draws the digitized book and lock motif
- update the shared header markup across every page and template to use the stacked Iron-Codex wordmark alongside the SVG
- refine navigation styling, including header height variables and active-state accents, to match the refreshed branding on desktop and mobile

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d724362234832297c5284f0ff3d082